### PR TITLE
fix: return 404 for unknown session IDs so clients re-initialize

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -627,15 +627,28 @@ export async function startHttpServer(
 
         await server.connect(transport);
         logger.debug("Server connected to transport");
+      } else if (mcpSessionId) {
+        // Unknown or expired session. The spec requires 404 here: it is the
+        // client's cue to re-initialize with a fresh session. Returning 400
+        // wedges the client until a human reconnects it, which matters now
+        // that idle sessions are swept (see session-registry.ts).
+        res.status(404).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32001,
+            message: "Session not found. Session may have expired.",
+          },
+          id: null,
+        });
+        return;
       } else {
-        // Invalid request - no session ID and not an initialize request
+        // No session ID and not an initialize request
         res.status(400).json({
           jsonrpc: "2.0",
           error: {
             code: -32000,
-            message: mcpSessionId
-              ? "Session not found. Session may have expired."
-              : "Invalid request. First request must be an initialize request.",
+            message:
+              "Invalid request. First request must be an initialize request.",
           },
           id: null,
         });
@@ -668,12 +681,26 @@ export async function startHttpServer(
   const handleMcpGet = async (req: Request, res: Response) => {
     const sessionId = req.headers["mcp-session-id"] as string;
 
-    if (!sessionId || !transports.has(sessionId)) {
+    if (!sessionId) {
       res.status(400).json({
         jsonrpc: "2.0",
         error: {
           code: -32000,
           message: "Invalid or missing session ID",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    if (!transports.has(sessionId)) {
+      // 404 tells the client to re-initialize rather than treating this as a
+      // hard failure - see the POST handler for why this matters.
+      res.status(404).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message: "Session not found. Session may have expired.",
         },
         id: null,
       });
@@ -703,12 +730,26 @@ export async function startHttpServer(
   const handleMcpDelete = async (req: Request, res: Response) => {
     const sessionId = req.headers["mcp-session-id"] as string;
 
-    if (!sessionId || !transports.has(sessionId)) {
+    if (!sessionId) {
       res.status(400).json({
         jsonrpc: "2.0",
         error: {
           code: -32000,
           message: "Invalid or missing session ID",
+        },
+        id: null,
+      });
+      return;
+    }
+
+    if (!transports.has(sessionId)) {
+      // 404 tells the client to re-initialize rather than treating this as a
+      // hard failure - see the POST handler for why this matters.
+      res.status(404).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message: "Session not found. Session may have expired.",
         },
         id: null,
       });


### PR DESCRIPTION
## Problem

The MCP Streamable HTTP spec requires **404** for a request carrying an unknown or expired `Mcp-Session-Id` — it is the client's cue to start a new session with a fresh `InitializeRequest`. We returned **400**, which clients treat as a hard error, so they stay wedged until a human reconnects them.

Hit immediately after the dev deploy of #19: the container restarted, and the connected claude.ai client could not recover on its own.

## Why it matters more now

#19 added idle session sweeping. Every session idle past `SESSION_IDLE_TIMEOUT_MS` now hits this path — so without the correct status code, the sweep would strand clients rather than let them reconnect transparently. The two changes need to ship together.

## Change

| Case | Before | After |
|---|---|---|
| POST, unknown/expired session id | 400 | **404** |
| GET, unknown/expired session id | 400 | **404** |
| DELETE, unknown/expired session id | 400 | **404** |
| POST, no session id, non-initialize | 400 | 400 (unchanged) |
| GET/DELETE, no session id | 400 | 400 (unchanged) |

A *missing* session ID still returns 400 — no re-initialize cue applies there.

## Verification

Against a locally built server:

```
POST unknown session -> HTTP 404  {"code":-32001,"message":"Session not found..."}
POST no session, non-init -> HTTP 400
GET  unknown session -> HTTP 404
GET  no session -> HTTP 400
```

Also confirmed on the same build that a normal session still initializes and serves `tools/list` (**144 tools**), that idle sessions are swept (`activeSessions` 3 → 0, `sweptSessions: 3`), and that a session receiving traffic every 2s survives well past a 5s idle timeout.

540 tests passing, lint and format clean.