### PR TITLE
fix: verify writes instead of trusting any 2xx (v1.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,4 +137,4 @@ itself when the digest changes. The final workflow step waits for the host's
 ## Important Account Settings
 
 ### Single Session per External ID
-Digital Samba accounts can have "single session per external ID" enabled in the dashboard. When active, each `externalId` can only have one active session; joining with an in-use `externalId` disconnects the previous session. This is dashboard-only and cannot be queried via API. Use unique `externalId` values when generating tokens, especially for moderators.
+Digital Samba accounts can have "single session per external ID" enabled in the dashboard. When active, each `externalId` can only have one active session; joining with an in-use `externalId` disconnects the previous session. It can only be *changed* in the dashboard, but it **is** readable via the API — `get-default-room-settings` returns it as `single_session_by_external_id_enabled` (verified on dev 2026-08-13). Use unique `externalId` values when generating tokens, especially for moderators.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 ## Project Overview
 
-Digital Samba Embedded API MCP Server - a Model Context Protocol server for Digital Samba's Embedded API, providing 144 tools and 37 resources for complete control over video conferencing features.
+Digital Samba Embedded API MCP Server - a Model Context Protocol server for Digital Samba's Embedded API, providing 145 tools and 37 resources for complete control over video conferencing features.
 
 **This is primarily a hosted remote MCP server** (production: https://mcp.digitalsamba.com, dev: https://mcp-dev.digitalsamba.com) that Digital Samba customers connect to from Claude Desktop or other MCP clients via OAuth. The npm package (`@digitalsamba/embedded-api-mcp-server`) is the legacy stdio distribution and is slated for deprecation.
 
@@ -75,7 +75,7 @@ src/
 │   └── http.ts           # Streamable HTTP transport + OAuth endpoints
 ├── types/                # TypeScript type definitions
 ├── resources/            # Read-only MCP resources (37)
-└── tools/                # MCP tools (144)
+└── tools/                # MCP tools (145)
     ├── room-management/       # 11 tools
     ├── session-management/    # 11 tools
     ├── recording-tools-adapter.ts  # 10 tools (the live implementation)
@@ -97,7 +97,7 @@ Implementation notes:
 
 ## MCP Implementation
 
-- 144 tools (actions) and 37 resources (read-only, `digitalsamba://` URIs)
+- 145 tools (actions) and 37 resources (read-only, `digitalsamba://` URIs)
 - Because many MCP clients don't expose resources, most resources have "reader tool" equivalents (`list-rooms`, `get-recordings`, etc.) — keep both in sync when adding functionality
 - All tools carry annotations (`readOnlyHint`, `destructiveHint`) via `src/tool-annotations.ts`
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Use the server URL `https://mcp.digitalsamba.com/mcp` with any MCP-compatible cl
 
 ## Available Tools
 
-The MCP server provides **144 tools** covering the complete Digital Samba API.
+The MCP server provides **145 tools** covering the complete Digital Samba API.
 
 ### Room Management (11 tools)
 | Tool | Description |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digitalsamba/embedded-api-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digitalsamba/embedded-api-mcp-server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitalsamba/embedded-api-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "mcpName": "io.github.digitalsamba/embedded-api-mcp-server",
   "packageManager": "npm@10.2.0",
   "description": "Digital Samba Embedded API MCP Server - Model Context Protocol server for Digital Samba's Embedded API",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:unit": "jest --testPathPatterns=tests/unit --forceExit",
     "test:integration": "jest --testPathPatterns=tests/integration --forceExit",
     "test:ci": "jest --coverage --forceExit",
+    "smoke": "node scripts/smoke-test.mjs",
     "size-check": "node scripts/build-size-check.js",
     "coverage:analyze": "node scripts/analyze-coverage.js",
     "release:check": "node scripts/pre-release-checklist.js"

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -363,7 +363,7 @@ async function run() {
 
   await knownIssue(
     "import-polls creates polls",
-    "API defect: /rooms/{id}/polls/import accepts and discards",
+    "API defect: PollsController@import hardcodes preview mode, never saves",
     async () => {
       const countPolls = async () => {
         const text = await call("list-polls", { room_id: created.roomId });
@@ -382,6 +382,19 @@ async function run() {
       return `${before} -> ${after}`;
     },
   );
+
+  await check("publish-poll-results refuses (no such endpoint)", async () => {
+    const error = await callExpectingError("publish-poll-results", {
+      room_id: created.roomId,
+      poll_id: pollId,
+      session_id: "00000000-0000-0000-0000-000000000000",
+    });
+    must(
+      /not supported/i.test(error),
+      `expected an unsupported-endpoint refusal, got: ${error.slice(0, 120)}`,
+    );
+    return "refused, as it must";
+  });
 
   await check("delete-poll removes it", async () => {
     await call("delete-poll", { room_id: created.roomId, poll_id: pollId });

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,723 @@
+#!/usr/bin/env node
+/**
+ * Live smoke test against a real Digital Samba account.
+ *
+ * Drives the built MCP server over stdio as a real client would, so this covers
+ * the whole stack — tool schemas, the CallTool dispatch (which matches on name
+ * substrings, where ordering matters), the handlers, and the API.
+ *
+ * THE RULE THIS SCRIPT EXISTS TO ENFORCE: a tool's success message is not
+ * evidence. Every write is verified by reading the state back. Two tools
+ * shipped in v1.1.0 reporting success while doing nothing, and no amount of
+ * reading their output would have revealed it.
+ *
+ * Usage:
+ *   DIGITAL_SAMBA_API_URL=https://<dev-host>/api/v1 node scripts/smoke-test.mjs
+ *
+ * Requires a built server (npm run build) and DIGITAL_SAMBA_DEVELOPER_KEY,
+ * which is read from the environment or .env.local — never passed on the
+ * command line, where it would be visible in the process list.
+ *
+ * Exit code 0 = all checks passed (known API defects excepted), 1 = failure.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { config as loadEnv } from "dotenv";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const EXPECTED_TOOL_COUNT = 144;
+
+// .env.local first (local dev secrets), then .env. Neither overrides a value
+// already exported in the environment.
+loadEnv({ path: resolve(ROOT, ".env.local") });
+loadEnv({ path: resolve(ROOT, ".env") });
+
+const KEY = process.env.DIGITAL_SAMBA_DEVELOPER_KEY;
+const API_URL = process.env.DIGITAL_SAMBA_API_URL;
+const KEEP = process.argv.includes("--keep");
+const ALLOW_PROD = process.argv.includes("--i-know-this-is-production");
+
+// ---------------------------------------------------------------------------
+// Safety
+// ---------------------------------------------------------------------------
+
+function refuse(message) {
+  console.error(`\n  REFUSING TO RUN\n\n${message}\n`);
+  process.exit(2);
+}
+
+if (!KEY) {
+  refuse(
+    `DIGITAL_SAMBA_DEVELOPER_KEY is not set.\n` +
+      `Add it to .env.local (gitignored) or export it before running.`,
+  );
+}
+
+if (!API_URL) {
+  // Deliberately no default. The client's built-in default is production, and
+  // this script creates and deletes rooms.
+  refuse(
+    `DIGITAL_SAMBA_API_URL is not set, and this script will not guess.\n\n` +
+      `The API client defaults to production (https://api.digitalsamba.com/api/v1),\n` +
+      `and this script creates and deletes rooms, libraries, roles and webhooks.\n` +
+      `Set it explicitly to the environment you mean to test, e.g.\n\n` +
+      `  DIGITAL_SAMBA_API_URL=https://<dev-host>/api/v1 node scripts/smoke-test.mjs`,
+  );
+}
+
+if (/(^|\/\/)api\.digitalsamba\.com/.test(API_URL) && !ALLOW_PROD) {
+  refuse(
+    `DIGITAL_SAMBA_API_URL points at PRODUCTION:\n  ${API_URL}\n\n` +
+      `This script creates and deletes real resources. If you genuinely mean to\n` +
+      `run it against production, pass --i-know-this-is-production.`,
+  );
+}
+
+if (!existsSync(resolve(ROOT, "dist/src/index.js"))) {
+  refuse(`dist/src/index.js not found. Run "npm run build" first.`);
+}
+
+// ---------------------------------------------------------------------------
+// Result tracking
+// ---------------------------------------------------------------------------
+
+const results = [];
+let currentGroup = "general";
+
+const group = (name) => {
+  currentGroup = name;
+  console.log(`\n── ${name} ${"─".repeat(Math.max(0, 58 - name.length))}`);
+};
+
+function record(status, name, detail) {
+  results.push({ status, name, detail, group: currentGroup });
+  const mark = {
+    PASS: "  ok  ",
+    FAIL: " FAIL ",
+    KNOWN: " known",
+    FIXED: " FIXED",
+    SKIP: " skip ",
+  }[status];
+  console.log(`${mark} ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+/**
+ * Run a check. `fn` must return a string describing the evidence that proves
+ * the operation happened, or throw.
+ */
+async function check(name, fn) {
+  try {
+    record("PASS", name, await fn());
+  } catch (error) {
+    record("FAIL", name, error.message);
+  }
+}
+
+/**
+ * A check that is currently expected to fail because of a defect outside this
+ * codebase. Keeps the gate green while staying visible — and shouts if the
+ * defect is ever fixed, so the exception can be removed.
+ */
+async function knownIssue(name, note, fn) {
+  try {
+    const evidence = await fn();
+    record("FIXED", name, `${note} — but it PASSED now (${evidence})`);
+  } catch (error) {
+    record("KNOWN", name, `${note} [${error.message}]`);
+  }
+}
+
+const skip = (name, why) => record("SKIP", name, why);
+
+// ---------------------------------------------------------------------------
+// MCP plumbing
+// ---------------------------------------------------------------------------
+
+let client;
+let transport;
+
+async function connect() {
+  transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [resolve(ROOT, "dist/src/index.js")],
+    // The key goes in the environment, never argv — argv is world-readable
+    // via the process list.
+    env: {
+      ...process.env,
+      DIGITAL_SAMBA_DEVELOPER_KEY: KEY,
+      DIGITAL_SAMBA_API_URL: API_URL,
+      TRANSPORT: "stdio",
+      DS_SHOW_VERSION_ON_START: "false",
+      DS_LOG_LEVEL: "error",
+    },
+    stderr: "ignore",
+  });
+
+  client = new Client(
+    { name: "smoke-test", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * How long to wait before retrying, or null if this is not a rate-limit error.
+ * The API says "Too Many Attempts. You may try again in N seconds" — honour
+ * that rather than guessing a backoff.
+ */
+function rateLimitDelay(message) {
+  if (!/429|Too Many Attempts/i.test(message)) return null;
+  const seconds = Number(message.match(/try again in (\d+) second/i)?.[1]);
+  return Math.min((Number.isFinite(seconds) ? seconds : 30) + 2, 90);
+}
+
+async function callOnce(tool, args) {
+  const result = await client.callTool({ name: tool, arguments: args });
+  const text = (result.content ?? [])
+    .map((part) => part.text ?? "")
+    .join("\n")
+    .trim();
+  if (result.isError) throw new Error(`${tool} errored: ${redact(text)}`);
+  return text;
+}
+
+/**
+ * Call a tool and return its text output. Throws if the tool reports an error.
+ *
+ * Retries on rate limiting: this script makes a burst of writes, which is
+ * exactly the shape the API throttles, and a 429 midway would otherwise be
+ * indistinguishable from a real failure — and would strand created resources.
+ */
+async function call(tool, args = {}, { retries = 4 } = {}) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await callOnce(tool, args);
+    } catch (error) {
+      const delay = rateLimitDelay(error.message);
+      if (delay === null || attempt >= retries) throw error;
+      console.log(`       rate limited, waiting ${delay}s (${tool})`);
+      await sleep(delay * 1000);
+    }
+  }
+}
+
+/** Call a tool expecting it to fail; returns the error text. */
+async function callExpectingError(tool, args = {}) {
+  try {
+    const text = await call(tool, args);
+    throw new Error(`expected an error, got success: ${text.slice(0, 120)}`);
+  } catch (error) {
+    return error.message;
+  }
+}
+
+/** Parse the first JSON object or array embedded in a tool's text output. */
+function parseJson(text) {
+  const start = text.search(/[[{]/);
+  if (start === -1) throw new Error("no JSON found in tool output");
+  const candidate = text.slice(start).replace(/```[\s\S]*$/, "");
+  for (let end = candidate.length; end > 0; end--) {
+    try {
+      return JSON.parse(candidate.slice(0, end));
+    } catch {
+      /* keep shrinking */
+    }
+  }
+  throw new Error("could not parse JSON from tool output");
+}
+
+/** Never let a key reach the console, including via error text. */
+function redact(text) {
+  return KEY ? String(text).split(KEY).join("<redacted>") : String(text);
+}
+
+const must = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+// ---------------------------------------------------------------------------
+// The run
+// ---------------------------------------------------------------------------
+
+const created = { roomId: null, libraryId: null, roleId: null, webhookId: null };
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+// Role names are capped at 30 characters by the API, so identifiers that go
+// into a name field use this compact form rather than the ISO stamp.
+const shortId = Date.now().toString(36);
+const tag = `smoke-${stamp}`;
+
+async function run() {
+  group("connection");
+
+  const { tools } = await client.listTools();
+  await check("tool count", async () => {
+    must(
+      tools.length === EXPECTED_TOOL_COUNT,
+      `expected ${EXPECTED_TOOL_COUNT} tools, got ${tools.length}`,
+    );
+    return `${tools.length} tools`;
+  });
+
+  await check("every tool has annotations", async () => {
+    const missing = tools.filter((t) => !t.annotations).map((t) => t.name);
+    must(missing.length === 0, `missing annotations: ${missing.join(", ")}`);
+    return "all annotated";
+  });
+
+  // -- rooms ---------------------------------------------------------------
+  group("rooms");
+
+  await check("create-room", async () => {
+    const room = parseJson(
+      await call("create-room", {
+        name: tag,
+        // The account default is de-DE; tests that read text back need en.
+        language: "en",
+        // Must be on from creation: enabling it later makes an empty chat
+        // export meaningless as evidence.
+        chat_persistence_enabled: true,
+        chat_enabled: true,
+        qa_enabled: true,
+        polls_enabled: true,
+        description: "smoke test - safe to delete",
+      }),
+    );
+    created.roomId = room.id;
+    must(room.id, "no room id returned");
+    must(room.language === "en", `language is ${room.language}, not en`);
+    must(room.chat_persistence_enabled === true, "chat persistence not set");
+    return `room ${room.id}`;
+  });
+
+  must(created.roomId, "cannot continue without a room");
+
+  await check("update-room persists (read back)", async () => {
+    await call("update-room", {
+      room_id: created.roomId,
+      max_participants: 42,
+      toolbar_position: "left",
+      video_tile_layout_mode: "bottom",
+    });
+    const room = parseJson(
+      await call("get-room-details", { room_id: created.roomId }),
+    );
+    must(room.max_participants === 42, "max_participants did not persist");
+    must(room.toolbar_position === "left", "toolbar_position did not persist");
+    must(
+      room.video_tile_layout_mode === "bottom",
+      "video_tile_layout_mode did not persist",
+    );
+    return "3 fields verified by read-back";
+  });
+
+  // -- polls ---------------------------------------------------------------
+  group("polls");
+
+  let pollId;
+  await check("create-poll appears in the room", async () => {
+    const text = await call("create-poll", {
+      room_id: created.roomId,
+      question: "smoke control poll",
+      options: [{ text: "Alpha" }, { text: "Beta" }],
+    });
+    pollId = text.match(/Poll ID: ([0-9a-f-]+)/i)?.[1];
+    must(pollId, "no poll id in output");
+    const room = parseJson(
+      await call("get-room-details", { room_id: created.roomId }),
+    );
+    must(
+      room.polls?.some((p) => p.id === pollId),
+      "poll absent from room after create",
+    );
+    return `poll ${pollId}`;
+  });
+
+  await check("update-poll persists (read back)", async () => {
+    await call("update-poll", {
+      room_id: created.roomId,
+      poll_id: pollId,
+      question: "smoke control poll EDITED",
+    });
+    const room = parseJson(
+      await call("get-room-details", { room_id: created.roomId }),
+    );
+    const poll = room.polls?.find((p) => p.id === pollId);
+    must(
+      poll?.question === "smoke control poll EDITED",
+      "question did not change",
+    );
+    return "question verified";
+  });
+
+  await knownIssue(
+    "import-polls creates polls",
+    "API defect: /rooms/{id}/polls/import accepts and discards",
+    async () => {
+      const before = parseJson(
+        await call("get-room-details", { room_id: created.roomId }),
+      ).polls?.length;
+      const template = await call("get-poll-import-template", {
+        room_id: created.roomId,
+      });
+      await call("import-polls", {
+        room_id: created.roomId,
+        csv_content: template,
+      });
+      const after = parseJson(
+        await call("get-room-details", { room_id: created.roomId }),
+      ).polls?.length;
+      must(after > before, `poll count unchanged at ${after}`);
+      return `${before} -> ${after}`;
+    },
+  );
+
+  await check("delete-poll removes it", async () => {
+    await call("delete-poll", { room_id: created.roomId, poll_id: pollId });
+    const room = parseJson(
+      await call("get-room-details", { room_id: created.roomId }),
+    );
+    must(!room.polls?.some((p) => p.id === pollId), "poll still present");
+    return "poll gone";
+  });
+
+  // -- quizzes -------------------------------------------------------------
+  group("quizzes");
+
+  let quizId;
+  await check("import-quizzes creates a quiz", async () => {
+    const template = await call("get-quiz-import-template", {
+      room_id: created.roomId,
+    });
+    await call("import-quizzes", {
+      room_id: created.roomId,
+      csv_content: template,
+    });
+    const list = await call("list-room-quizzes", { room_id: created.roomId });
+    const quizzes = parseJson(list);
+    must(quizzes.length > 0, "no quizzes after import");
+    quizId = quizzes[0].id;
+    return `quiz ${quizId}`;
+  });
+
+  if (quizId) {
+    await check("update-quiz persists (read back)", async () => {
+      await call("update-quiz", {
+        room_id: created.roomId,
+        quiz_id: quizId,
+        title: "smoke quiz EDITED",
+        passing_score: 55,
+      });
+      const quiz = parseJson(
+        await call("get-quiz", { room_id: created.roomId, quiz_id: quizId }),
+      );
+      must(quiz.title === "smoke quiz EDITED", "title did not change");
+      must(quiz.passing_score === 55, "passing_score did not change");
+      return "title + passing_score verified";
+    });
+
+    await check("delete-quiz removes it", async () => {
+      await call("delete-quiz", { room_id: created.roomId, quiz_id: quizId });
+      const list = await call("list-room-quizzes", { room_id: created.roomId });
+      must(!list.includes(quizId), "quiz still listed");
+      return "quiz gone";
+    });
+  }
+
+  // -- libraries -----------------------------------------------------------
+  group("libraries");
+
+  let folderId;
+  let fileId;
+
+  await check("create-library", async () => {
+    const text = await call("create-library", {
+      externalId: tag,
+      name: `${tag} library`,
+    });
+    created.libraryId = text.match(/ID: ([0-9a-f-]+)/i)?.[1];
+    must(created.libraryId, "no library id in output");
+    const verified = parseJson(
+      await call("verify-library-id", { libraryId: created.libraryId }),
+    );
+    must(
+      verified.library?.id === created.libraryId,
+      "library not readable back",
+    );
+    return `library ${created.libraryId}`;
+  });
+
+  if (created.libraryId) {
+    await check("create + rename folder (read back)", async () => {
+      const text = await call("create-library-folder", {
+        libraryId: created.libraryId,
+        name: "smoke folder",
+      });
+      folderId = text.match(/Folder ID: ([0-9a-f-]+)/i)?.[1];
+      must(folderId, "no folder id in output");
+      await call("update-library-folder", {
+        libraryId: created.libraryId,
+        folderId,
+        name: "smoke folder RENAMED",
+      });
+      const tree = parseJson(
+        await call("get-library-hierarchy", { libraryId: created.libraryId }),
+      );
+      const folder = tree.hierarchy?.folders?.find((f) => f.id === folderId);
+      must(folder, "folder missing from hierarchy");
+      must(folder.name === "smoke folder RENAMED", "folder rename did not land");
+      return "folder created and renamed";
+    });
+
+    await check("create + move file (read back)", async () => {
+      const text = await call("create-library-file", {
+        libraryId: created.libraryId,
+        name: "smoke.pdf",
+        folderId,
+        fileSize: 1024,
+      });
+      fileId = text.match(/File ID: ([0-9a-f-]+)/i)?.[1];
+      must(fileId, "no file id in output");
+      await call("move-library-file", { libraryId: created.libraryId, fileId });
+      const tree = parseJson(
+        await call("get-library-hierarchy", { libraryId: created.libraryId }),
+      );
+      must(
+        tree.hierarchy?.files?.some((f) => f.id === fileId),
+        "file not at library root after move",
+      );
+      return "file created and moved to root";
+    });
+
+    await check("delete file + folder (read back)", async () => {
+      // Without the prerequisite ids this would call the tool with undefined
+      // and fail on validation, which reads as a delete bug rather than a
+      // skipped setup step.
+      must(fileId && folderId, "skipped: file or folder was never created");
+      await call("delete-library-file", {
+        libraryId: created.libraryId,
+        fileId,
+      });
+      await call("delete-library-folder", {
+        libraryId: created.libraryId,
+        folderId,
+      });
+      const tree = parseJson(
+        await call("get-library-hierarchy", { libraryId: created.libraryId }),
+      );
+      must(!tree.hierarchy?.files?.some((f) => f.id === fileId), "file remains");
+      must(
+        !tree.hierarchy?.folders?.some((f) => f.id === folderId),
+        "folder remains",
+      );
+      return "both removed";
+    });
+  }
+
+  // -- roles ---------------------------------------------------------------
+  group("roles");
+
+  await check("create-role", async () => {
+    const text = await call("create-role", {
+      name: `smoke-role-${shortId}`,
+      displayName: "Smoke Role",
+      permissions: { broadcast: true, screenshare: false },
+    });
+    created.roleId = text.match(/ID: ([0-9a-f-]+)/i)?.[1];
+    must(created.roleId, "no role id in output");
+    return `role ${created.roleId}`;
+  });
+
+  if (created.roleId) {
+    // This is the regression that shipped: update-role sent camelCase
+    // displayName to a snake_case API, so the rename was silently dropped
+    // while permissions in the same call applied.
+    await check("update-role rename actually applies", async () => {
+      await call("update-role", {
+        roleId: created.roleId,
+        displayName: "Smoke Role RENAMED",
+        permissions: { broadcast: false, screenshare: true },
+      });
+      const role = await call("get-role", { roleId: created.roleId });
+      must(
+        role.includes("Smoke Role RENAMED"),
+        "displayName was NOT applied (the v1.1.0 silent-drop bug)",
+      );
+      must(role.includes("screenshare"), "permissions did not apply");
+      return "rename and permissions both verified";
+    });
+
+    await check("delete-role removes it", async () => {
+      await call("delete-role", { roleId: created.roleId });
+      created.roleId = null;
+      const roles = await call("get-roles", { limit: 50 });
+      must(!roles.includes("Smoke Role"), "role still listed");
+      return "role gone";
+    });
+  }
+
+  // -- webhooks ------------------------------------------------------------
+  group("webhooks");
+
+  await check("create + update webhook (read back)", async () => {
+    const text = await call("create-webhook", {
+      name: `smoke-hook-${shortId}`,
+      endpoint: "https://example.com/smoke",
+      events: ["session_started"],
+    });
+    created.webhookId = text.match(/ID: ([0-9a-f-]+)/i)?.[1];
+    must(created.webhookId, "no webhook id in output");
+    await call("update-webhook", {
+      webhookId: created.webhookId,
+      endpoint: "https://example.com/smoke-UPDATED",
+    });
+    const list = await call("list-webhooks", { limit: 50 });
+    must(
+      list.includes("https://example.com/smoke-UPDATED"),
+      "endpoint update did not land",
+    );
+    return "created and updated";
+  });
+
+  // -- honest failures -----------------------------------------------------
+  group("must-fail-honestly");
+
+  await check("update-recording reports failure", async () => {
+    // The API has no update endpoint. This must be an error, not a bare
+    // message a client would read as success.
+    const message = await callExpectingError("update-recording", {
+      recording_id: "00000000-0000-0000-0000-000000000000",
+      name: "nope",
+    });
+    must(/not supported/i.test(message), `unexpected message: ${message}`);
+    return "errors as it should";
+  });
+
+  await check("get-room-details on a deleted room 404s", async () => {
+    const message = await callExpectingError("get-room-details", {
+      room_id: "00000000-0000-0000-0000-000000000000",
+    });
+    must(/404|not found/i.test(message), `unexpected message: ${message}`);
+    return "404 surfaced";
+  });
+
+  // -- needs a live session ------------------------------------------------
+  group("session-dependent");
+
+  const liveOnly = [
+    ["send-chat-message", "API defect: delivers nothing (verified 2026-08-13)"],
+    ["create-question", "needs an active session"],
+    ["raise-participant-hand", "needs a live participant"],
+    ["start-transcription", "needs an active session"],
+    ["connect-phone", "needs telephony on the account"],
+  ];
+  for (const [tool, why] of liveOnly) skip(tool, why);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup — must run even when checks fail
+// ---------------------------------------------------------------------------
+
+async function cleanup() {
+  if (KEEP) {
+    console.log(`\nLeaving resources in place (--keep): ${JSON.stringify(created)}`);
+    return;
+  }
+  group("cleanup");
+
+  // Cleanup retries harder than the checks do: a stranded room or library on a
+  // shared account is worse than a slow run.
+  const opts = { retries: 8 };
+  const removals = [
+    [
+      "room",
+      created.roomId,
+      () =>
+        call(
+          "delete-room",
+          { room_id: created.roomId, delete_resources: true },
+          opts,
+        ),
+    ],
+    [
+      "library",
+      created.libraryId,
+      () => call("delete-library", { libraryId: created.libraryId }, opts),
+    ],
+    [
+      "role",
+      created.roleId,
+      () => call("delete-role", { roleId: created.roleId }, opts),
+    ],
+    [
+      "webhook",
+      created.webhookId,
+      () => call("delete-webhook", { webhookId: created.webhookId }, opts),
+    ],
+  ];
+
+  for (const [label, id, remove] of removals) {
+    if (!id) continue;
+    try {
+      await remove();
+      record("PASS", `cleanup ${label}`, id);
+    } catch (error) {
+      record("FAIL", `cleanup ${label}`, `${id} left behind: ${error.message}`);
+      console.log(
+        `       MANUAL CLEANUP NEEDED: ${label} ${id}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+function summarise() {
+  const count = (status) => results.filter((r) => r.status === status).length;
+  const failed = results.filter((r) => r.status === "FAIL");
+  const fixed = results.filter((r) => r.status === "FIXED");
+
+  console.log(`\n${"═".repeat(64)}`);
+  console.log(
+    `  ${count("PASS")} passed   ${count("FAIL")} failed   ` +
+      `${count("KNOWN")} known-issue   ${count("FIXED")} newly-fixed   ` +
+      `${count("SKIP")} skipped`,
+  );
+  console.log("═".repeat(64));
+
+  if (fixed.length) {
+    console.log(`\n  A known defect now passes — remove its exception:`);
+    for (const r of fixed) console.log(`    - ${r.name}`);
+  }
+
+  if (failed.length) {
+    console.log(`\n  Failures:`);
+    for (const r of failed) console.log(`    - [${r.group}] ${r.name}: ${r.detail}`);
+  }
+
+  return failed.length === 0;
+}
+
+let ok = false;
+try {
+  await connect();
+  await run();
+} catch (error) {
+  record("FAIL", "run aborted", redact(error.message));
+} finally {
+  try {
+    await cleanup();
+  } catch (error) {
+    record("FAIL", "cleanup aborted", redact(error.message));
+  }
+  ok = summarise();
+  await transport?.close().catch(() => {});
+}
+
+process.exit(ok ? 0 : 1);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -633,7 +633,10 @@ async function run() {
   group("session-dependent");
 
   const liveOnly = [
-    ["send-chat-message", "API defect: delivers nothing (verified 2026-08-13)"],
+    [
+      "send-chat-message",
+      "signalling server has no chat endpoint; backend fix scheduled (proven 2026-08-14)",
+    ],
     ["create-question", "needs an active session"],
     ["raise-participant-hand", "needs a live participant"],
     ["start-transcription", "needs an active session"],

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -30,7 +30,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_TOOL_COUNT = 144;
+const EXPECTED_TOOL_COUNT = 145;
 
 // .env.local first (local dev secrets), then .env. Neither overrides a value
 // already exported in the environment.
@@ -246,7 +246,12 @@ const must = (condition, message) => {
 // The run
 // ---------------------------------------------------------------------------
 
-const created = { roomId: null, libraryId: null, roleId: null, webhookId: null };
+const created = {
+  roomId: null,
+  libraryId: null,
+  roleId: null,
+  webhookId: null,
+};
 const stamp = new Date().toISOString().replace(/[:.]/g, "-");
 // Role names are capped at 30 characters by the API, so identifiers that go
 // into a name field use this compact form rather than the ISO stamp.
@@ -329,12 +334,12 @@ async function run() {
     });
     pollId = text.match(/Poll ID: ([0-9a-f-]+)/i)?.[1];
     must(pollId, "no poll id in output");
-    const room = parseJson(
-      await call("get-room-details", { room_id: created.roomId }),
+    const polls = parseJson(
+      await call("list-polls", { room_id: created.roomId }),
     );
     must(
-      room.polls?.some((p) => p.id === pollId),
-      "poll absent from room after create",
+      polls.some((p) => p.id === pollId),
+      "poll absent from list-polls after create",
     );
     return `poll ${pollId}`;
   });
@@ -345,10 +350,10 @@ async function run() {
       poll_id: pollId,
       question: "smoke control poll EDITED",
     });
-    const room = parseJson(
-      await call("get-room-details", { room_id: created.roomId }),
+    const polls = parseJson(
+      await call("list-polls", { room_id: created.roomId }),
     );
-    const poll = room.polls?.find((p) => p.id === pollId);
+    const poll = polls.find((p) => p.id === pollId);
     must(
       poll?.question === "smoke control poll EDITED",
       "question did not change",
@@ -360,9 +365,11 @@ async function run() {
     "import-polls creates polls",
     "API defect: /rooms/{id}/polls/import accepts and discards",
     async () => {
-      const before = parseJson(
-        await call("get-room-details", { room_id: created.roomId }),
-      ).polls?.length;
+      const countPolls = async () => {
+        const text = await call("list-polls", { room_id: created.roomId });
+        return text.startsWith("No polls") ? 0 : parseJson(text).length;
+      };
+      const before = await countPolls();
       const template = await call("get-poll-import-template", {
         room_id: created.roomId,
       });
@@ -370,9 +377,7 @@ async function run() {
         room_id: created.roomId,
         csv_content: template,
       });
-      const after = parseJson(
-        await call("get-room-details", { room_id: created.roomId }),
-      ).polls?.length;
+      const after = await countPolls();
       must(after > before, `poll count unchanged at ${after}`);
       return `${before} -> ${after}`;
     },
@@ -380,10 +385,8 @@ async function run() {
 
   await check("delete-poll removes it", async () => {
     await call("delete-poll", { room_id: created.roomId, poll_id: pollId });
-    const room = parseJson(
-      await call("get-room-details", { room_id: created.roomId }),
-    );
-    must(!room.polls?.some((p) => p.id === pollId), "poll still present");
+    const remaining = await call("list-polls", { room_id: created.roomId });
+    must(!remaining.includes(pollId), "poll still present");
     return "poll gone";
   });
 
@@ -471,7 +474,10 @@ async function run() {
       );
       const folder = tree.hierarchy?.folders?.find((f) => f.id === folderId);
       must(folder, "folder missing from hierarchy");
-      must(folder.name === "smoke folder RENAMED", "folder rename did not land");
+      must(
+        folder.name === "smoke folder RENAMED",
+        "folder rename did not land",
+      );
       return "folder created and renamed";
     });
 
@@ -511,7 +517,10 @@ async function run() {
       const tree = parseJson(
         await call("get-library-hierarchy", { libraryId: created.libraryId }),
       );
-      must(!tree.hierarchy?.files?.some((f) => f.id === fileId), "file remains");
+      must(
+        !tree.hierarchy?.files?.some((f) => f.id === fileId),
+        "file remains",
+      );
       must(
         !tree.hierarchy?.folders?.some((f) => f.id === folderId),
         "folder remains",
@@ -626,7 +635,9 @@ async function run() {
 
 async function cleanup() {
   if (KEEP) {
-    console.log(`\nLeaving resources in place (--keep): ${JSON.stringify(created)}`);
+    console.log(
+      `\nLeaving resources in place (--keep): ${JSON.stringify(created)}`,
+    );
     return;
   }
   group("cleanup");
@@ -669,9 +680,7 @@ async function cleanup() {
       record("PASS", `cleanup ${label}`, id);
     } catch (error) {
       record("FAIL", `cleanup ${label}`, `${id} left behind: ${error.message}`);
-      console.log(
-        `       MANUAL CLEANUP NEEDED: ${label} ${id}`,
-      );
+      console.log(`       MANUAL CLEANUP NEEDED: ${label} ${id}`);
     }
   }
 }
@@ -698,7 +707,8 @@ function summarise() {
 
   if (failed.length) {
     console.log(`\n  Failures:`);
-    for (const r of failed) console.log(`    - [${r.group}] ${r.name}: ${r.detail}`);
+    for (const r of failed)
+      console.log(`    - [${r.group}] ${r.name}: ${r.detail}`);
   }
 
   return failed.length === 0;

--- a/src/digital-samba-api.ts
+++ b/src/digital-samba-api.ts
@@ -132,6 +132,17 @@ export type {
   RoleCreateSettings,
 };
 
+/**
+ * Body returned by a write endpoint.
+ *
+ * Several Digital Samba write endpoints are undocumented in the OpenAPI spec or
+ * document an empty success body, and the client normalises 204s and empty
+ * bodies to `{}`. Callers must therefore treat an empty object as "the API
+ * accepted the request but told us nothing" — never as proof the write landed.
+ * Use a read-back to confirm writes that matter.
+ */
+export type WriteResult = Record<string, unknown>;
+
 export class DigitalSambaApiClient {
   protected apiBaseUrl: string;
   protected cache?: MemoryCache;
@@ -219,6 +230,18 @@ export class DigitalSambaApiClient {
    * // Example internal usage
    * const rooms = await this.request<ApiResponse<Room>>('/rooms');
    */
+  /**
+   * Drop cached GET responses.
+   *
+   * Called after writes that a read-back verifies, so the confirming read
+   * cannot be served the pre-write state from cache.
+   */
+  protected invalidateApiCache(): void {
+    if (this.cache) {
+      this.cache.invalidateNamespace("api");
+    }
+  }
+
   protected async request<T>(
     endpoint: string,
     options: RequestInit = {},
@@ -927,8 +950,8 @@ export class DigitalSambaApiClient {
   async raiseParticipantHand(
     roomId: string,
     participantId: string,
-  ): Promise<void> {
-    await this.request<void>(
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/participants/${participantId}/raise-hand`,
       { method: "POST" },
     );
@@ -940,8 +963,8 @@ export class DigitalSambaApiClient {
   async lowerParticipantHand(
     roomId: string,
     participantId: string,
-  ): Promise<void> {
-    await this.request<void>(
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/participants/${participantId}/lower-hand`,
       { method: "POST" },
     );
@@ -953,8 +976,8 @@ export class DigitalSambaApiClient {
   async raisePhoneParticipantHand(
     roomId: string,
     callId: string,
-  ): Promise<void> {
-    await this.request<void>(
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/phone-participants/${callId}/raise-hand`,
       { method: "POST" },
     );
@@ -966,8 +989,8 @@ export class DigitalSambaApiClient {
   async lowerPhoneParticipantHand(
     roomId: string,
     callId: string,
-  ): Promise<void> {
-    await this.request<void>(
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/phone-participants/${callId}/lower-hand`,
       { method: "POST" },
     );
@@ -976,8 +999,11 @@ export class DigitalSambaApiClient {
   /**
    * Mute a phone participant
    */
-  async mutePhoneParticipant(roomId: string, callId: string): Promise<void> {
-    await this.request<void>(
+  async mutePhoneParticipant(
+    roomId: string,
+    callId: string,
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/phone-participants/${callId}/mute`,
       { method: "POST" },
     );
@@ -986,8 +1012,11 @@ export class DigitalSambaApiClient {
   /**
    * Unmute a phone participant
    */
-  async unmutePhoneParticipant(roomId: string, callId: string): Promise<void> {
-    await this.request<void>(
+  async unmutePhoneParticipant(
+    roomId: string,
+    callId: string,
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/phone-participants/${callId}/unmute`,
       { method: "POST" },
     );
@@ -1516,8 +1545,9 @@ export class DigitalSambaApiClient {
       message: string;
       participant?: QAParticipant;
     },
-  ): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/chat`, {
+  ): Promise<WriteResult> {
+    this.invalidateApiCache();
+    return this.request<WriteResult>(`/rooms/${roomId}/chat`, {
       method: "POST",
       body: JSON.stringify(data),
     });
@@ -1534,8 +1564,9 @@ export class DigitalSambaApiClient {
       anonymous?: boolean;
       breakout_id?: string;
     },
-  ): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/questions`, {
+  ): Promise<WriteResult> {
+    this.invalidateApiCache();
+    return this.request<WriteResult>(`/rooms/${roomId}/questions`, {
       method: "POST",
       body: JSON.stringify(data),
     });
@@ -1551,11 +1582,14 @@ export class DigitalSambaApiClient {
       participant: QAParticipant;
       question: string;
     },
-  ): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/questions/${questionId}`, {
-      method: "PATCH",
-      body: JSON.stringify(data),
-    });
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
+      `/rooms/${roomId}/questions/${questionId}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(data),
+      },
+    );
   }
 
   /**
@@ -1644,8 +1678,9 @@ export class DigitalSambaApiClient {
       answer: string;
       private?: boolean;
     },
-  ): Promise<void> {
-    await this.request<void>(
+  ): Promise<WriteResult> {
+    this.invalidateApiCache();
+    return this.request<WriteResult>(
       `/rooms/${roomId}/questions/${questionId}/answers`,
       {
         method: "POST",
@@ -1665,8 +1700,8 @@ export class DigitalSambaApiClient {
       participant: QAParticipant;
       answer: string;
     },
-  ): Promise<void> {
-    await this.request<void>(
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(
       `/rooms/${roomId}/questions/${questionId}/answers/${answerId}`,
       {
         method: "PATCH",
@@ -1969,6 +2004,8 @@ export class DigitalSambaApiClient {
         `Digital Samba API error (${response.status}): ${errorText}`,
       );
     }
+
+    this.invalidateApiCache();
 
     const text = await response.text();
     if (!text || text.trim() === "") return {};
@@ -2938,8 +2975,8 @@ export class DigitalSambaApiClient {
   /**
    * Connect to SIP phone bridge
    */
-  async connectPhone(roomId: string): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/phone/connect`, {
+  async connectPhone(roomId: string): Promise<WriteResult> {
+    return this.request<WriteResult>(`/rooms/${roomId}/phone/connect`, {
       method: "POST",
     });
   }
@@ -2947,8 +2984,8 @@ export class DigitalSambaApiClient {
   /**
    * Disconnect from SIP phone bridge
    */
-  async disconnectPhone(roomId: string): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/phone/disconnect`, {
+  async disconnectPhone(roomId: string): Promise<WriteResult> {
+    return this.request<WriteResult>(`/rooms/${roomId}/phone/disconnect`, {
       method: "POST",
     });
   }
@@ -3113,8 +3150,8 @@ export class DigitalSambaApiClient {
   async startRestreamer(
     roomId: string,
     options: RestreamerOptions,
-  ): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/restreamers/start`, {
+  ): Promise<WriteResult> {
+    return this.request<WriteResult>(`/rooms/${roomId}/restreamers/start`, {
       method: "POST",
       body: JSON.stringify(options),
     });
@@ -3123,8 +3160,8 @@ export class DigitalSambaApiClient {
   /**
    * Stop live streaming
    */
-  async stopRestreamer(roomId: string): Promise<void> {
-    await this.request<void>(`/rooms/${roomId}/restreamers/stop`, {
+  async stopRestreamer(roomId: string): Promise<WriteResult> {
+    return this.request<WriteResult>(`/rooms/${roomId}/restreamers/stop`, {
       method: "POST",
     });
   }

--- a/src/digital-samba-api.ts
+++ b/src/digital-samba-api.ts
@@ -2582,7 +2582,8 @@ export class DigitalSambaApiClient {
   async createWhiteboard(
     libraryId: string,
     settings: {
-      name: string;
+      /** Ignored by the API, which assigns its own "Whiteboard N" name. */
+      name?: string;
       folder_id?: string;
     },
   ): Promise<{

--- a/src/digital-samba-api.ts
+++ b/src/digital-samba-api.ts
@@ -2935,6 +2935,10 @@ export class DigitalSambaApiClient {
 
   /**
    * Publish poll results
+   *
+   * @deprecated The API does not route this path — no `publish` action exists in
+   * the backend. Kept only so the dead path stays visible; publish-poll-results
+   * refuses without calling it.
    */
   async publishPollResults(pollId: string, sessionId: string): Promise<void> {
     await this.request<void>(

--- a/src/tools/analytics-tools/index.ts
+++ b/src/tools/analytics-tools/index.ts
@@ -110,7 +110,8 @@ export function registerAnalyticsTools(): Tool[] {
           period: {
             type: "string",
             enum: ["day", "week", "month", "year"],
-            description: "Analytics period",
+            description:
+              "Analytics period. Note: observed to have no effect on its own — passing period alone returns all-time figures. Use dateStart/dateEnd to bound the range.",
           },
         },
         required: [],

--- a/src/tools/analytics-tools/index.ts
+++ b/src/tools/analytics-tools/index.ts
@@ -82,7 +82,8 @@ export function registerAnalyticsTools(): Tool[] {
           period: {
             type: "string",
             enum: ["day", "week", "month", "year"],
-            description: "Analytics period",
+            description:
+              "Shorthand for a date range ending today (day = last 24h, week = last 7 days, month, year). Translated by this server into dateStart/dateEnd, which the API takes instead; ignored if you supply either date yourself.",
           },
         },
         required: [],
@@ -111,7 +112,7 @@ export function registerAnalyticsTools(): Tool[] {
             type: "string",
             enum: ["day", "week", "month", "year"],
             description:
-              "Analytics period. Note: observed to have no effect on its own — passing period alone returns all-time figures. Use dateStart/dateEnd to bound the range.",
+              "Shorthand for a date range ending today (day = last 24h, week = last 7 days, month, year). Translated by this server into dateStart/dateEnd, which the API takes instead; ignored if you supply either date yourself.",
           },
         },
         required: [],
@@ -140,7 +141,8 @@ export function registerAnalyticsTools(): Tool[] {
           period: {
             type: "string",
             enum: ["day", "week", "month", "year"],
-            description: "Analytics period for grouping",
+            description:
+              "Shorthand for a date range ending today (day = last 24h, week = last 7 days, month, year). Translated by this server into dateStart/dateEnd, which the API takes instead; ignored if you supply either date yourself.",
           },
         },
       },
@@ -224,6 +226,46 @@ export function registerAnalyticsTools(): Tool[] {
 }
 
 /**
+ * Translate the `period` shorthand into the date range the API actually accepts.
+ *
+ * The statistics endpoints take `date_start` and `date_end` only — there is no
+ * `period` parameter on any of them, so sending one had no effect and callers
+ * asking for "last week" silently received all-time figures. Deriving an
+ * explicit range here makes the parameter mean what the tools advertise.
+ *
+ * Returns undefined for an unknown period, so an unrecognised value falls back
+ * to the unbounded query rather than inventing a range.
+ */
+function periodToDateRange(
+  period?: string,
+): { date_start: string; date_end: string } | undefined {
+  if (!period) return undefined;
+
+  const end = new Date();
+  const start = new Date(end);
+
+  switch (period) {
+    case "day":
+      start.setUTCDate(start.getUTCDate() - 1);
+      break;
+    case "week":
+      start.setUTCDate(start.getUTCDate() - 7);
+      break;
+    case "month":
+      start.setUTCMonth(start.getUTCMonth() - 1);
+      break;
+    case "year":
+      start.setUTCFullYear(start.getUTCFullYear() - 1);
+      break;
+    default:
+      return undefined;
+  }
+
+  const asDate = (d: Date) => d.toISOString().slice(0, 10);
+  return { date_start: asDate(start), date_end: asDate(end) };
+}
+
+/**
  * Handle analytics tool execution
  *
  * @param toolName - The name of the tool being executed
@@ -239,14 +281,21 @@ export async function executeAnalyticsTool(
   try {
     const analytics = new AnalyticsResource(apiClient);
 
+    // An explicit range always wins; `period` only fills in when neither bound
+    // was given. `period` itself is never forwarded — the API has no such
+    // parameter and ignores it.
+    const derivedRange =
+      args.dateStart || args.dateEnd
+        ? undefined
+        : periodToDateRange(args.period);
+
     // Build filters from arguments and convert to snake_case
     const filters: AnalyticsFilters = {
-      date_start: args.dateStart,
-      date_end: args.dateEnd,
+      date_start: args.dateStart ?? derivedRange?.date_start,
+      date_end: args.dateEnd ?? derivedRange?.date_end,
       room_id: args.roomId,
       session_id: args.sessionId,
       participant_id: args.participantId,
-      period: args.period,
     };
 
     // Remove undefined and null values

--- a/src/tools/communication-management/index.ts
+++ b/src/tools/communication-management/index.ts
@@ -1558,10 +1558,58 @@ async function handleSendChatMessage(
   const { roomId, message, participant } = params;
 
   // The chat export is the only read-back available, and it only contains
-  // anything when the room persists chat. Without persistence an empty export
-  // proves nothing, so don't verify against it — claiming the message failed
-  // would be as wrong as claiming it was delivered.
+  // anything when the room persists chat. Where the room does persist, the
+  // export decides the outcome; where it does not, an empty export would prove
+  // nothing on its own — but we no longer need it to.
+  //
+  // Delivery is impossible on every account: the API forwards the message to
+  // `{signalling}/rooms/{uuid}/chatMessages`, which no released build of the
+  // signalling server routes, and then reports 200 regardless. Verified on
+  // 2026-08-14 by raw curl in a live session — two API sends returned 200 and
+  // reached neither the room nor any read endpoint, while a message typed in the
+  // browser the same minute persisted and exported correctly. So when there is
+  // no read-back to run, report the known failure rather than "accepted,
+  // unverified", which reassures the caller about something that cannot happen.
+  //
+  // A fix is scheduled backend-side. Once it lands, rooms that persist chat
+  // start passing on their own; delete this branch to restore the honest
+  // unverified wording for the rest.
   const persists = await roomPersistsChat(roomId, apiClient);
+
+  if (!persists) {
+    // Still issue the request. It costs nothing, and once the backend fix lands
+    // it is the difference between a delivered message and a lost one.
+    try {
+      logger.info("Sending chat message (unverifiable room)", { roomId });
+      await apiClient.sendChatMessage(roomId, { message, participant });
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error sending chat message: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `Chat message NOT delivered to room ${roomId}. The API accepted the ` +
+            `request and returned success, but the platform cannot deliver it: the ` +
+            `signalling server has no chat endpoint, so nothing reaches the room. ` +
+            `No read-back is available for this room either, so this cannot be ` +
+            `confirmed from here. A backend fix is scheduled; until it ships, treat ` +
+            `every send as failed.`,
+        },
+      ],
+      isError: true,
+    };
+  }
 
   return verifiedWrite({
     required: { roomId, message },
@@ -1572,20 +1620,18 @@ async function handleSendChatMessage(
       logger.info("Sending chat message", { roomId });
       return apiClient.sendChatMessage(roomId, { message, participant });
     },
-    verify: persists
-      ? async () => {
-          const exported = await apiClient.exportChatMessages(roomId, {
-            format: "json",
-          });
-          const found = exportContains(exported, message);
-          return {
-            landed: found,
-            evidence: found
-              ? "the message appears in the room's chat export"
-              : "the message is absent from the room's chat export",
-          };
-        }
-      : undefined,
+    verify: async () => {
+      const exported = await apiClient.exportChatMessages(roomId, {
+        format: "json",
+      });
+      const found = exportContains(exported, message);
+      return {
+        landed: found,
+        evidence: found
+          ? "the message appears in the room's chat export"
+          : "the message is absent from the room's chat export",
+      };
+    },
   });
 }
 

--- a/src/tools/communication-management/index.ts
+++ b/src/tools/communication-management/index.ts
@@ -52,29 +52,31 @@ interface ToolDefinition {
 /**
  * Chat's own participant schema.
  *
- * `POST /rooms/{room}/chat` validates `message` and nothing else, so this object
- * is dropped by the API before it reaches the signalling server. It is the right
- * shape — the Q&A endpoints take exactly this and resolve it to a real
- * participant — chat just never wired it up, which is the leading explanation
- * for why chat sends deliver nothing at all. Kept so callers can already pass a
- * sender, and described so nobody believes it works today.
+ * Dropped twice over. `SendMessageRequest` validates `message` alone, so this
+ * object never leaves Laravel; and it would not matter if it did, because the
+ * signalling server has no chat endpoint on `master` at all — sending chat is a
+ * WebSocket-only operation there, while Q&A was deliberately given an external
+ * HTTP surface. So chat sends 404 internally and are reported as 200.
+ *
+ * Kept in the schema because it is the shape Q&A uses and the shape a real
+ * implementation would want, but described so nobody expects it to do anything.
  */
 const chatParticipantSchema = {
   type: "object",
   description:
-    "Intended sender: either { id } or { name, external_id }. NOT HONOURED TODAY — the chat endpoint validates only the message text and drops this, which is why messages currently go nowhere. Accepted so callers are ready when the API resolves senders the way the Q&A endpoints already do.",
+    "Intended sender: either { id } or { name, external_id }. HAS NO EFFECT — the chat endpoint validates only the message text and drops this. Note that chat sending does not work at all on any account (see the tool description), so this is not the reason a message fails to arrive.",
   properties: {
     id: {
       type: "string",
-      description: "UUID of an existing participant (not honoured today)",
+      description: "UUID of an existing participant (no effect)",
     },
     name: {
       type: "string",
-      description: "Participant display name (not honoured today)",
+      description: "Participant display name (no effect)",
     },
     external_id: {
       type: "string",
-      description: "External participant ID (not honoured today)",
+      description: "External participant ID (no effect)",
     },
   },
 };
@@ -394,7 +396,7 @@ export function registerCommunicationTools(): ToolDefinition[] {
     {
       name: "send-chat-message",
       description:
-        '[Communication Management] Send a chat message to a room. Use when users say: "send a message to the room", "post in chat", "send chat message". Requires roomId and message.',
+        '[Communication Management] Send a chat message to a room. Use when users say: "send a message to the room", "post in chat", "send chat message". Requires roomId and message. KNOWN BROKEN: the platform cannot deliver these — the signalling server has no chat endpoint, so the API accepts the message, drops it, and returns success. This tool reads the chat back and reports the failure instead of repeating that claim. Not fixable from here.',
       annotations: getToolAnnotations("send-chat-message", "Send Chat Message"),
       inputSchema: {
         type: "object",

--- a/src/tools/communication-management/index.ts
+++ b/src/tools/communication-management/index.ts
@@ -49,6 +49,36 @@ interface ToolDefinition {
 /**
  * Shared schema for the Q&A participant identity object
  */
+/**
+ * Chat's own participant schema.
+ *
+ * `POST /rooms/{room}/chat` validates `message` and nothing else, so this object
+ * is dropped by the API before it reaches the signalling server. It is the right
+ * shape — the Q&A endpoints take exactly this and resolve it to a real
+ * participant — chat just never wired it up, which is the leading explanation
+ * for why chat sends deliver nothing at all. Kept so callers can already pass a
+ * sender, and described so nobody believes it works today.
+ */
+const chatParticipantSchema = {
+  type: "object",
+  description:
+    "Intended sender: either { id } or { name, external_id }. NOT HONOURED TODAY — the chat endpoint validates only the message text and drops this, which is why messages currently go nowhere. Accepted so callers are ready when the API resolves senders the way the Q&A endpoints already do.",
+  properties: {
+    id: {
+      type: "string",
+      description: "UUID of an existing participant (not honoured today)",
+    },
+    name: {
+      type: "string",
+      description: "Participant display name (not honoured today)",
+    },
+    external_id: {
+      type: "string",
+      description: "External participant ID (not honoured today)",
+    },
+  },
+};
+
 const qaParticipantSchema = {
   type: "object",
   description:
@@ -377,7 +407,7 @@ export function registerCommunicationTools(): ToolDefinition[] {
             type: "string",
             description: "The chat message text",
           },
-          participant: qaParticipantSchema,
+          participant: chatParticipantSchema,
         },
         required: ["roomId", "message"],
       },

--- a/src/tools/communication-management/index.ts
+++ b/src/tools/communication-management/index.ts
@@ -31,6 +31,7 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { DigitalSambaApiClient } from "../../digital-samba-api.js";
 import logger from "../../logger.js";
 import { getToolAnnotations } from "../../tool-annotations.js";
+import { verifiedWrite } from "../verified-write.js";
 
 /**
  * Tool definition interface
@@ -640,49 +641,49 @@ export async function executeCommunicationTool(
         params,
         apiClient,
         (c, p) => c.dismissQuestion(p.roomId, p.questionId, p.participant),
-        "Dismissed question",
+        "Dismissed",
       );
     case "reopen-question":
       return handleQuestionAction(
         params,
         apiClient,
         (c, p) => c.reopenQuestion(p.roomId, p.questionId, p.participant),
-        "Reopened question",
+        "Reopened",
       );
     case "upvote-question":
       return handleQuestionAction(
         params,
         apiClient,
         (c, p) => c.upvoteQuestion(p.roomId, p.questionId, p.participant),
-        "Upvoted question",
+        "Upvoted",
       );
     case "remove-question-vote":
       return handleQuestionAction(
         params,
         apiClient,
         (c, p) => c.removeQuestionVote(p.roomId, p.questionId, p.participant),
-        "Removed vote from question",
+        "Removed vote from",
       );
     case "start-question-live-answer":
       return handleQuestionAction(
         params,
         apiClient,
         (c, p) => c.startLiveAnswer(p.roomId, p.questionId, p.participant),
-        "Started live answer for question",
+        "Started live answer for",
       );
     case "stop-question-live-answer":
       return handleQuestionAction(
         params,
         apiClient,
         (c, p) => c.stopLiveAnswer(p.roomId, p.questionId, p.participant),
-        "Stopped live answer for question",
+        "Stopped live answer for",
       );
     case "cancel-question-live-answer":
       return handleQuestionAction(
         params,
         apiClient,
         (c, p) => c.cancelLiveAnswer(p.roomId, p.questionId, p.participant),
-        "Cancelled live answer for question",
+        "Cancelled live answer for",
       );
     case "answer-question":
       return handleAnswerQuestion(params, apiClient);
@@ -1498,30 +1499,21 @@ async function handleDeleteSessionResources(
 async function runQaHandler(
   requiredFields: Record<string, any>,
   action: () => Promise<any>,
-  successText: string,
+  verb: string,
+  describe: string,
 ): Promise<any> {
-  for (const [field, value] of Object.entries(requiredFields)) {
-    if (value === undefined || value === null || value === "") {
-      return {
-        content: [{ type: "text", text: `${field} is required.` }],
-        isError: true,
-      };
-    }
-  }
-
-  try {
-    await action();
-    return {
-      content: [{ type: "text", text: successText }],
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.error("Q&A tool error", { error: message });
-    return {
-      content: [{ type: "text", text: message }],
-      isError: true,
-    };
-  }
+  // No read-back for these: the Q&A action endpoints have no matching read that
+  // would distinguish "applied" from "accepted and ignored" without pulling the
+  // whole Q&A export per call. verifiedWrite reports the response body's
+  // evidence when there is any, and says plainly that it is unverified when
+  // there is not.
+  return verifiedWrite({
+    required: requiredFields,
+    describe,
+    verb,
+    errorLabel: `on ${describe}`,
+    action,
+  });
 }
 
 /**
@@ -1532,14 +1524,111 @@ async function handleSendChatMessage(
   apiClient: DigitalSambaApiClient,
 ): Promise<any> {
   const { roomId, message, participant } = params;
-  return runQaHandler(
-    { roomId, message },
-    async () => {
+
+  // The chat export is the only read-back available, and it only contains
+  // anything when the room persists chat. Without persistence an empty export
+  // proves nothing, so don't verify against it — claiming the message failed
+  // would be as wrong as claiming it was delivered.
+  const persists = await roomPersistsChat(roomId, apiClient);
+
+  return verifiedWrite({
+    required: { roomId, message },
+    describe: `a chat message to room ${roomId}`,
+    verb: "Sent",
+    errorLabel: "sending chat message",
+    action: () => {
       logger.info("Sending chat message", { roomId });
-      await apiClient.sendChatMessage(roomId, { message, participant });
+      return apiClient.sendChatMessage(roomId, { message, participant });
     },
-    `Sent chat message to room ${roomId}`,
-  );
+    verify: persists
+      ? async () => {
+          const exported = await apiClient.exportChatMessages(roomId, {
+            format: "json",
+          });
+          const found = exportContains(exported, message);
+          return {
+            landed: found,
+            evidence: found
+              ? "the message appears in the room's chat export"
+              : "the message is absent from the room's chat export",
+          };
+        }
+      : undefined,
+  });
+}
+
+/**
+ * Whether a room persists chat, i.e. whether the chat export can serve as a
+ * read-back. Returns false if the room cannot be read.
+ */
+async function roomPersistsChat(
+  roomId: string,
+  apiClient: DigitalSambaApiClient,
+): Promise<boolean> {
+  try {
+    const room = await apiClient.getRoom(roomId);
+    return room?.chat_persistence_enabled === true;
+  } catch (error) {
+    logger.warn("Could not read room settings to verify chat delivery", {
+      roomId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+/**
+ * Whether an export payload contains the given text.
+ *
+ * Exports come back as an opaque string whose JSON shape is undocumented, so
+ * match on the text itself rather than on a field path that may not hold.
+ */
+function exportContains(exported: string, needle: string): boolean {
+  if (!exported) return false;
+  if (exported.includes(needle)) return true;
+  // JSON-encoded payloads escape quotes and other characters in the text.
+  return exported.includes(JSON.stringify(needle).slice(1, -1));
+}
+
+/**
+ * Recover the id of the record carrying the given text from an export payload.
+ *
+ * The create endpoints return no id and there is no list-questions tool, so
+ * this is the only way to hand the caller something it can act on. Walks the
+ * payload rather than assuming a field path, since the export shape is
+ * undocumented.
+ *
+ * @returns the id, or undefined if the payload is not JSON or has no match
+ */
+function findIdForText(exported: string, text: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(exported);
+  } catch {
+    return undefined;
+  }
+
+  const stack: unknown[] = [parsed];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (Array.isArray(node)) {
+      stack.push(...node);
+      continue;
+    }
+    if (!node || typeof node !== "object") continue;
+
+    const record = node as Record<string, unknown>;
+    const matches = Object.entries(record).some(
+      ([key, value]) => key !== "id" && value === text,
+    );
+    if (matches) {
+      const id = record.id;
+      if (typeof id === "string" || typeof id === "number") return String(id);
+    }
+    stack.push(...Object.values(record));
+  }
+
+  return undefined;
 }
 
 /**
@@ -1556,19 +1645,40 @@ async function handleCreateQuestion(
   apiClient: DigitalSambaApiClient,
 ): Promise<any> {
   const { roomId, question, participant, anonymous, breakoutId } = params;
-  return runQaHandler(
-    { roomId, question, participant },
-    async () => {
+
+  return verifiedWrite({
+    required: { roomId, question, participant },
+    describe: `a question in room ${roomId}`,
+    verb: "Created",
+    errorLabel: "creating question",
+    action: () => {
       logger.info("Creating question", { roomId });
-      await apiClient.createQuestion(roomId, {
+      return apiClient.createQuestion(roomId, {
         participant,
         question,
         ...(anonymous !== undefined && { anonymous }),
         ...(breakoutId !== undefined && { breakout_id: breakoutId }),
       });
     },
-    `Created question in room ${roomId}`,
-  );
+    // The create endpoint returns no id, so read the Q&A back both to confirm
+    // the question exists and to recover the id the caller needs to act on it.
+    verify: async () => {
+      const exported = await apiClient.exportQA(roomId, { format: "json" });
+      if (!exportContains(exported, question)) {
+        return {
+          landed: false,
+          evidence: "the question is absent from the room's Q&A export",
+        };
+      }
+      const id = findIdForText(exported, question);
+      return {
+        landed: true,
+        evidence: id
+          ? `question id ${id}`
+          : "the question appears in the room's Q&A export",
+      };
+    },
+  });
 }
 
 /**
@@ -1588,12 +1698,13 @@ async function handleUpdateQuestion(
     { roomId, questionId, question, participant },
     async () => {
       logger.info("Updating question", { roomId, questionId });
-      await apiClient.updateQuestion(roomId, questionId, {
+      return apiClient.updateQuestion(roomId, questionId, {
         participant,
         question,
       });
     },
-    `Updated question ${questionId}`,
+    "Updated",
+    `question ${questionId}`,
   );
 }
 
@@ -1606,17 +1717,18 @@ async function handleQuestionAction(
   action: (
     client: DigitalSambaApiClient,
     params: { roomId: string; questionId: string; participant: any },
-  ) => Promise<void>,
-  successPrefix: string,
+  ) => Promise<unknown>,
+  verb: string,
 ): Promise<any> {
   const { roomId, questionId, participant } = params;
   return runQaHandler(
     { roomId, questionId, participant },
     async () => {
-      logger.info(successPrefix, { roomId, questionId });
-      await action(apiClient, params);
+      logger.info(`${verb} question`, { roomId, questionId });
+      return action(apiClient, params);
     },
-    `${successPrefix} ${questionId}`,
+    verb,
+    `question ${questionId}`,
   );
 }
 
@@ -1634,18 +1746,34 @@ async function handleAnswerQuestion(
   apiClient: DigitalSambaApiClient,
 ): Promise<any> {
   const { roomId, questionId, answer, participant } = params;
-  return runQaHandler(
-    { roomId, questionId, answer, participant },
-    async () => {
+
+  return verifiedWrite({
+    required: { roomId, questionId, answer, participant },
+    describe: `question ${questionId}`,
+    verb: "Answered",
+    errorLabel: "answering question",
+    action: () => {
       logger.info("Answering question", { roomId, questionId });
-      await apiClient.answerQuestion(roomId, questionId, {
+      return apiClient.answerQuestion(roomId, questionId, {
         participant,
         answer,
         ...(params.private !== undefined && { private: params.private }),
       });
     },
-    `Answered question ${questionId}`,
-  );
+    verify: async () => {
+      const exported = await apiClient.exportQA(roomId, { format: "json" });
+      const found = exportContains(exported, answer);
+      const id = found ? findIdForText(exported, answer) : undefined;
+      return {
+        landed: found,
+        evidence: found
+          ? id
+            ? `answer id ${id}`
+            : "the answer appears in the room's Q&A export"
+          : "the answer is absent from the room's Q&A export",
+      };
+    },
+  });
 }
 
 /**
@@ -1666,12 +1794,13 @@ async function handleUpdateAnswer(
     { roomId, questionId, answerId, answer, participant },
     async () => {
       logger.info("Updating answer", { roomId, questionId, answerId });
-      await apiClient.updateAnswer(roomId, questionId, answerId, {
+      return apiClient.updateAnswer(roomId, questionId, answerId, {
         participant,
         answer,
       });
     },
-    `Updated answer ${answerId}`,
+    "Updated",
+    `answer ${answerId}`,
   );
 }
 
@@ -1692,8 +1821,9 @@ async function handleDeleteAnswer(
     { roomId, questionId, answerId, participant },
     async () => {
       logger.info("Deleting answer", { roomId, questionId, answerId });
-      await apiClient.deleteAnswer(roomId, questionId, answerId, participant);
+      return apiClient.deleteAnswer(roomId, questionId, answerId, participant);
     },
-    `Deleted answer ${answerId}`,
+    "Deleted",
+    `answer ${answerId}`,
   );
 }

--- a/src/tools/library-management/index.ts
+++ b/src/tools/library-management/index.ts
@@ -497,7 +497,7 @@ export function registerLibraryTools(): ToolDefinition[] {
     {
       name: "copy-library-content",
       description:
-        '[Content Library] Copy files or folders within/between libraries. Use when users say: "copy file", "duplicate folder", "copy to another library", "clone content", "duplicate files". Requires source/target library IDs, content type and ID. Can rename during copy.',
+        '[Content Library] Copy content within/between libraries. Use when users say: "copy file", "duplicate folder", "copy to another library", "clone content". LIMITED: the API has no copy endpoint, so only webapps can be truly duplicated (by recreating them from their URL). Stored files are refused — their contents cannot be duplicated server-side. Folders are created empty, without their contents. Requires source/target library IDs, content type and ID. Can rename during copy.',
       annotations: getToolAnnotations(
         "copy-library-content",
         "Copy Library Content",
@@ -2082,26 +2082,51 @@ async function handleCopyLibraryContent(
         contentId,
       );
 
-      // Create new file in target library
-      const fileData: any = {
-        name: newName || sourceFile.name,
-        size: sourceFile.size,
-        mime_type: sourceFile.type || "application/octet-stream",
-      };
-      if (targetFolderId) fileData.folder_id = targetFolderId;
+      // A webapp is fully described by its URL, so it can genuinely be
+      // duplicated — recreate it rather than leaving a typeless placeholder.
+      if (sourceFile.url) {
+        const webappData: { url: string; name?: string; folder_id?: string } = {
+          url: sourceFile.url,
+          name: newName || sourceFile.name,
+        };
+        if (targetFolderId) webappData.folder_id = targetFolderId;
 
-      const newFile = await apiClient.createLibraryFile(
-        targetLibraryId,
-        fileData,
-      );
+        const newWebapp = await apiClient.createWebapp(
+          targetLibraryId,
+          webappData,
+        );
 
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Copied webapp "${sourceFile.name}" to library ${targetLibraryId} ` +
+                `as "${newWebapp.name}" (id ${newWebapp.id}, type ${newWebapp.type}, ` +
+                `url ${newWebapp.url}).`,
+            },
+          ],
+        };
+      }
+
+      // Anything else is a stored file, and the API exposes no copy endpoint for
+      // one — the only public library writes are create + upload. This used to
+      // call createLibraryFile with the source's name and size, which produced
+      // an empty placeholder stuck at status `uploading` and reported it as
+      // "Successfully copied file". Nothing was ever copied, for any file type.
       return {
         content: [
           {
             type: "text",
-            text: `Successfully copied file "${sourceFile.name}" to library ${targetLibraryId}. New file ID: ${newFile.file_id}. Upload URL: ${newFile.external_storage_url}`,
+            text:
+              `Copying stored files is not supported: the Digital Samba API has no ` +
+              `copy endpoint, and file contents cannot be duplicated server-side. ` +
+              `"${sourceFile.name}" was not copied and nothing was created in ` +
+              `library ${targetLibraryId}. To place a new file there, use ` +
+              `create-library-file and upload the content to the URL it returns.`,
           },
         ],
+        isError: true,
       };
     } else {
       // For folders, we need to recursively copy
@@ -2127,7 +2152,10 @@ async function handleCopyLibraryContent(
         content: [
           {
             type: "text",
-            text: `Successfully copied folder to library ${targetLibraryId}. New folder ID: ${newFolder.id}. Note: Folder contents were not copied - this would require recursive copying.`,
+            text:
+              `Created an empty folder "${newFolder.name ?? folderData.name}" (id ${newFolder.id}) in ` +
+              `library ${targetLibraryId}. Its contents were NOT copied: the API has ` +
+              `no copy endpoint, so only the folder itself could be created.`,
           },
         ],
       };

--- a/src/tools/library-management/index.ts
+++ b/src/tools/library-management/index.ts
@@ -348,7 +348,7 @@ export function registerLibraryTools(): ToolDefinition[] {
     {
       name: "create-whiteboard",
       description:
-        '[Content Library] Create a collaborative whiteboard in library. Use when users say: "create whiteboard", "add whiteboard", "create drawing board", "make collaborative board". Requires libraryId and name. Optional folderId. For visual collaboration.',
+        '[Content Library] Create a collaborative whiteboard in library. Use when users say: "create whiteboard", "add whiteboard", "create drawing board", "make collaborative board". Requires libraryId. Optional folderId. Note: the API names whiteboards itself ("Whiteboard 1", "Whiteboard 2", ...) and ignores any name supplied. For visual collaboration.',
       annotations: getToolAnnotations("create-whiteboard", "Create Whiteboard"),
       inputSchema: {
         type: "object",
@@ -359,14 +359,15 @@ export function registerLibraryTools(): ToolDefinition[] {
           },
           name: {
             type: "string",
-            description: "Name of the whiteboard",
+            description:
+              "Ignored by the API, which assigns its own name (Whiteboard 1, Whiteboard 2, ...). Accepted for backward compatibility; the created whiteboard's actual name is reported back.",
           },
           folderId: {
             type: "string",
             description: "Folder ID to place the whiteboard in",
           },
         },
-        required: ["libraryId", "name"],
+        required: ["libraryId"],
       },
     },
 
@@ -1669,7 +1670,7 @@ async function handleCreateWebapp(
  * Handle create whiteboard
  */
 async function handleCreateWhiteboard(
-  params: { libraryId: string; name: string; folderId?: string },
+  params: { libraryId: string; name?: string; folderId?: string },
   apiClient: DigitalSambaApiClient,
 ): Promise<any> {
   const { libraryId, name, folderId } = params;
@@ -1686,22 +1687,14 @@ async function handleCreateWhiteboard(
     };
   }
 
-  if (!name || name.trim() === "") {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Whiteboard name is required.",
-        },
-      ],
-      isError: true,
-    };
-  }
-
-  logger.info("Creating whiteboard", { libraryId, name, folderId });
+  // No name check: the API names whiteboards itself and ignores whatever is
+  // sent, so demanding one only forced callers to invent a value that was
+  // then discarded. The created whiteboard's real name is reported below.
+  logger.info("Creating whiteboard", { libraryId, folderId });
 
   try {
-    const whiteboardData: any = { name };
+    const whiteboardData: any = {};
+    if (name !== undefined) whiteboardData.name = name;
     if (folderId !== undefined) whiteboardData.folder_id = folderId;
 
     const result = await apiClient.createWhiteboard(libraryId, whiteboardData);

--- a/src/tools/live-session-controls/index.ts
+++ b/src/tools/live-session-controls/index.ts
@@ -903,6 +903,42 @@ async function handlePhoneParticipantMute(
 }
 
 /**
+ * Explain why telephony is unavailable for a room, or undefined if it is
+ * available (or if we cannot tell).
+ *
+ * Only used to turn the API's misleading success into an honest refusal — if
+ * the room cannot be read, say nothing and let the call proceed rather than
+ * blocking on a check that is itself unreliable.
+ */
+async function telephonyUnavailableReason(
+  roomId: string,
+  apiClient: DigitalSambaApiClient,
+): Promise<string | undefined> {
+  let room;
+  try {
+    room = await apiClient.getRoom(roomId);
+  } catch (error) {
+    logger.warn("Could not check telephony availability", {
+      roomId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+
+  if (room?.telephony_enabled === false) {
+    return (
+      `Telephony is not enabled for room ${roomId}, so the phone bridge cannot ` +
+      `connect. Note the API returns success for this call regardless, which is ` +
+      `why this is checked here. Enable telephony for the room, or check that ` +
+      `the account's plan includes it (can_enable_telephony in ` +
+      `get-default-room-settings).`
+    );
+  }
+
+  return undefined;
+}
+
+/**
  * Handle connect phone
  */
 async function handleConnectPhone(
@@ -919,6 +955,17 @@ async function handleConnectPhone(
   }
 
   logger.info("Connecting phone bridge", { room_id });
+
+  // The connect endpoint returns 2xx even when the account has no telephony,
+  // and nothing connects — verified on an account with can_enable_telephony
+  // false. Since the API will not say no, check first and say it here.
+  const unavailable = await telephonyUnavailableReason(room_id, apiClient);
+  if (unavailable) {
+    return {
+      content: [{ type: "text", text: unavailable }],
+      isError: true,
+    };
+  }
 
   try {
     const result = await apiClient.connectPhone(room_id);

--- a/src/tools/live-session-controls/index.ts
+++ b/src/tools/live-session-controls/index.ts
@@ -31,6 +31,7 @@ import { getApiKeyFromRequest } from "../../auth.js";
 import { DigitalSambaApiClient } from "../../digital-samba-api.js";
 import logger from "../../logger.js";
 import { getToolAnnotations } from "../../tool-annotations.js";
+import { describeWriteResult, verifiedWrite } from "../verified-write.js";
 
 /**
  * Tool definition interface
@@ -757,32 +758,12 @@ async function handleRaiseParticipantHand(
 
   logger.info("Raising participant hand", { room_id, participant_id });
 
-  try {
-    await apiClient.raiseParticipantHand(room_id, participant_id);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully raised hand for participant ${participant_id} in room ${room_id}.`,
-        },
-      ],
-    };
-  } catch (error) {
-    logger.error("Error raising participant hand", {
-      room_id,
-      participant_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error raising hand: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
-  }
+  return verifiedWrite({
+    verb: "Raised hand for",
+    describe: `participant ${participant_id} in room ${room_id}`,
+    errorLabel: "raising hand",
+    action: () => apiClient.raiseParticipantHand(room_id, participant_id),
+  });
 }
 
 /**
@@ -810,32 +791,12 @@ async function handleLowerParticipantHand(
 
   logger.info("Lowering participant hand", { room_id, participant_id });
 
-  try {
-    await apiClient.lowerParticipantHand(room_id, participant_id);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully lowered hand for participant ${participant_id} in room ${room_id}.`,
-        },
-      ],
-    };
-  } catch (error) {
-    logger.error("Error lowering participant hand", {
-      room_id,
-      participant_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error lowering hand: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
-  }
+  return verifiedWrite({
+    verb: "Lowered hand for",
+    describe: `participant ${participant_id} in room ${room_id}`,
+    errorLabel: "lowering hand",
+    action: () => apiClient.lowerParticipantHand(room_id, participant_id),
+  });
 }
 
 /**
@@ -863,32 +824,12 @@ async function handleRaisePhoneParticipantHand(
 
   logger.info("Raising phone participant hand", { room_id, call_id });
 
-  try {
-    await apiClient.raisePhoneParticipantHand(room_id, call_id);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully raised hand for phone participant ${call_id} in room ${room_id}.`,
-        },
-      ],
-    };
-  } catch (error) {
-    logger.error("Error raising phone participant hand", {
-      room_id,
-      call_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error raising hand: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
-  }
+  return verifiedWrite({
+    verb: "Raised hand for",
+    describe: `phone participant ${call_id} in room ${room_id}`,
+    errorLabel: "raising hand",
+    action: () => apiClient.raisePhoneParticipantHand(room_id, call_id),
+  });
 }
 
 /**
@@ -916,32 +857,12 @@ async function handleLowerPhoneParticipantHand(
 
   logger.info("Lowering phone participant hand", { room_id, call_id });
 
-  try {
-    await apiClient.lowerPhoneParticipantHand(room_id, call_id);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully lowered hand for phone participant ${call_id} in room ${room_id}.`,
-        },
-      ],
-    };
-  } catch (error) {
-    logger.error("Error lowering phone participant hand", {
-      room_id,
-      call_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error lowering hand: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
-  }
+  return verifiedWrite({
+    verb: "Lowered hand for",
+    describe: `phone participant ${call_id} in room ${room_id}`,
+    errorLabel: "lowering hand",
+    action: () => apiClient.lowerPhoneParticipantHand(room_id, call_id),
+  });
 }
 
 /**
@@ -970,36 +891,15 @@ async function handlePhoneParticipantMute(
 
   logger.info(`Phone participant ${action}`, { room_id, call_id });
 
-  try {
-    if (action === "mute") {
-      await apiClient.mutePhoneParticipant(room_id, call_id);
-    } else {
-      await apiClient.unmutePhoneParticipant(room_id, call_id);
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully ${action}d phone participant ${call_id} in room ${room_id}.`,
-        },
-      ],
-    };
-  } catch (error) {
-    logger.error(`Error on phone participant ${action}`, {
-      room_id,
-      call_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error on ${action}: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
-    };
-  }
+  return verifiedWrite({
+    verb: action === "mute" ? "Muted" : "Unmuted",
+    describe: `phone participant ${call_id} in room ${room_id}`,
+    errorLabel: `on ${action}`,
+    action: () =>
+      action === "mute"
+        ? apiClient.mutePhoneParticipant(room_id, call_id)
+        : apiClient.unmutePhoneParticipant(room_id, call_id),
+  });
 }
 
 /**
@@ -1021,12 +921,16 @@ async function handleConnectPhone(
   logger.info("Connecting phone bridge", { room_id });
 
   try {
-    await apiClient.connectPhone(room_id);
+    const result = await apiClient.connectPhone(room_id);
     return {
       content: [
         {
           type: "text",
-          text: `Successfully connected phone bridge for room ${room_id}.`,
+          text: describeWriteResult(
+            result,
+            "Connected the phone bridge for",
+            `room ${room_id}`,
+          ),
         },
       ],
     };
@@ -1069,12 +973,16 @@ async function handleDisconnectPhone(
   logger.info("Disconnecting phone bridge", { room_id });
 
   try {
-    await apiClient.disconnectPhone(room_id);
+    const result = await apiClient.disconnectPhone(room_id);
     return {
       content: [
         {
           type: "text",
-          text: `Successfully disconnected phone bridge for room ${room_id}.`,
+          text: describeWriteResult(
+            result,
+            "Disconnected the phone bridge for",
+            `room ${room_id}`,
+          ),
         },
       ],
     };
@@ -1143,14 +1051,22 @@ async function handleStartRestreamer(
   });
 
   try {
-    await apiClient.startRestreamer(room_id, { type, server_url, stream_key });
+    const result = await apiClient.startRestreamer(room_id, {
+      type,
+      server_url,
+      stream_key,
+    });
 
     const destination = type || server_url;
     return {
       content: [
         {
           type: "text",
-          text: `Successfully started live streaming from room ${room_id} to ${destination}.`,
+          text: describeWriteResult(
+            result,
+            "Started live streaming from",
+            `room ${room_id} to ${destination}`,
+          ),
         },
       ],
     };
@@ -1198,12 +1114,16 @@ async function handleStopRestreamer(
   logger.info("Stopping restreamer", { room_id });
 
   try {
-    await apiClient.stopRestreamer(room_id);
+    const result = await apiClient.stopRestreamer(room_id);
     return {
       content: [
         {
           type: "text",
-          text: `Successfully stopped live streaming for room ${room_id}.`,
+          text: describeWriteResult(
+            result,
+            "Stopped live streaming for",
+            `room ${room_id}`,
+          ),
         },
       ],
     };

--- a/src/tools/poll-management/index.ts
+++ b/src/tools/poll-management/index.ts
@@ -30,6 +30,7 @@ import { DigitalSambaApiClient } from "../../digital-samba-api.js";
 import logger from "../../logger.js";
 import { normalizeBoolean } from "../../utils.js";
 import { getToolAnnotations } from "../../tool-annotations.js";
+import { countOf, verifiedWrite } from "../verified-write.js";
 
 /**
  * Tool definition interface
@@ -928,22 +929,46 @@ async function handleImportPolls(
 
   logger.info("Importing polls from CSV", { room_id });
 
+  // Count first: the import endpoint returns 2xx with an empty body whether or
+  // not it created anything, so the delta is the only proof it did.
+  const before = await countPolls(room_id, apiClient);
+
+  return verifiedWrite({
+    describe: `polls into room ${room_id}`,
+    verb: "Imported",
+    errorLabel: "importing polls",
+    action: () => apiClient.importPolls(room_id, csv_content),
+    verify: async () => {
+      const after = await countPolls(room_id, apiClient);
+      if (before === undefined || after === undefined) {
+        throw new Error("could not list the room's polls");
+      }
+      const created = after - before;
+      return {
+        landed: created > 0,
+        evidence:
+          created > 0
+            ? `room now has ${after} poll(s), up from ${before}`
+            : `room still has ${after} poll(s); no poll was created`,
+      };
+    },
+  });
+}
+
+/**
+ * Count the polls in a room, or undefined if they cannot be listed.
+ */
+async function countPolls(
+  roomId: string,
+  apiClient: DigitalSambaApiClient,
+): Promise<number | undefined> {
   try {
-    await apiClient.importPolls(room_id, csv_content);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully imported polls into room ${room_id}`,
-        },
-      ],
-    };
+    return countOf(await apiClient.getPolls(roomId));
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.error("Error importing polls", { room_id, error: message });
-    return {
-      content: [{ type: "text", text: `Error importing polls: ${message}` }],
-      isError: true,
-    };
+    logger.warn("Could not count polls for import verification", {
+      roomId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
   }
 }

--- a/src/tools/poll-management/index.ts
+++ b/src/tools/poll-management/index.ts
@@ -237,10 +237,35 @@ export function registerPollTools(): ToolDefinition[] {
           },
           session_id: {
             type: "string",
-            description: "The ID of the specific session (optional)",
+            description:
+              "The ID of the session to publish results for. Required: the API rejects the request without it.",
           },
         },
-        required: ["room_id", "poll_id"],
+        required: ["room_id", "poll_id", "session_id"],
+      },
+    },
+    {
+      name: "list-polls",
+      description:
+        '[Poll Management - TOOL] List all polls in a room. Use when users say: "list polls", "show polls", "what polls exist", "get room polls", "show surveys". Requires room_id. Returns each poll with its ID, question, type and options.',
+      annotations: getToolAnnotations("list-polls", "List Polls"),
+      inputSchema: {
+        type: "object",
+        properties: {
+          room_id: {
+            type: "string",
+            description: "The ID of the room to list polls for",
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of polls to return",
+          },
+          offset: {
+            type: "number",
+            description: "Number of polls to skip for pagination",
+          },
+        },
+        required: ["room_id"],
       },
     },
     {
@@ -312,6 +337,8 @@ export async function executePollTool(
       return handleDeleteRoomPolls(params, apiClient);
     case "publish-poll-results":
       return handlePublishPollResults(params, apiClient);
+    case "list-polls":
+      return handleListPolls(params, apiClient);
     case "get-poll-import-template":
       return handleGetPollImportTemplate(params, apiClient);
     case "import-polls":
@@ -899,6 +926,63 @@ async function handleGetPollImportTemplate(
     });
     return {
       content: [{ type: "text", text: `Error getting template: ${message}` }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Handle list polls
+ *
+ * Added because there was no way to list a room's polls: the API exposes
+ * GET /rooms/{id}/polls and the client has getPolls, but no tool surfaced it,
+ * so callers had to pull the entire room object and read its polls array.
+ */
+async function handleListPolls(
+  params: { room_id: string; limit?: number; offset?: number },
+  apiClient: DigitalSambaApiClient,
+): Promise<any> {
+  const { room_id, limit, offset } = params;
+
+  if (!room_id || room_id.trim() === "") {
+    return {
+      content: [{ type: "text", text: "Room ID is required." }],
+      isError: true,
+    };
+  }
+
+  logger.info("Listing polls", { room_id });
+
+  try {
+    const response = await apiClient.getPolls(room_id, {
+      ...(limit !== undefined && { limit }),
+      ...(offset !== undefined && { offset }),
+    });
+    const polls = Array.isArray(response)
+      ? response
+      : ((response as any)?.data ?? []);
+
+    if (polls.length === 0) {
+      return {
+        content: [{ type: "text", text: `No polls found in room ${room_id}.` }],
+      };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `Found ${polls.length} poll(s) in room ${room_id}:\n\n` +
+            JSON.stringify(polls, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("Error listing polls", { room_id, error: message });
+    return {
+      content: [{ type: "text", text: `Error listing polls: ${message}` }],
       isError: true,
     };
   }

--- a/src/tools/poll-management/index.ts
+++ b/src/tools/poll-management/index.ts
@@ -10,7 +10,8 @@
  * - delete-poll: Delete a specific poll
  * - delete-session-polls: Delete all polls for a session
  * - delete-room-polls: Delete all polls for all sessions in a room
- * - publish-poll-results: Publish poll results to participants
+ * - publish-poll-results: unsupported; the API has no publish-results endpoint,
+ *   so this reports failure rather than silently doing nothing
  *
  * @module tools/poll-management
  * @author Digital Samba Team
@@ -219,7 +220,7 @@ export function registerPollTools(): ToolDefinition[] {
     {
       name: "publish-poll-results",
       description:
-        '[Poll Management] Publish/share poll results with participants. Use when users say: "show poll results", "publish poll results", "share voting results", "display poll outcome", "reveal survey results". Requires room_id, poll_id, and session_id. Makes results visible to all participants.',
+        "[Poll Management] NOT SUPPORTED — the Digital Samba API has no publish-results endpoint, so this tool always reports failure and changes nothing. Retained so that callers get an explicit error rather than a silent no-op. To read poll results, use export-poll-results.",
       annotations: getToolAnnotations(
         "publish-poll-results",
         "Publish Poll Results",
@@ -238,7 +239,7 @@ export function registerPollTools(): ToolDefinition[] {
           session_id: {
             type: "string",
             description:
-              "The ID of the session to publish results for. Required: the API rejects the request without it.",
+              "The ID of the session. Unused — there is no endpoint to send it to.",
           },
         },
         required: ["room_id", "poll_id", "session_id"],
@@ -336,7 +337,7 @@ export async function executePollTool(
     case "delete-room-polls":
       return handleDeleteRoomPolls(params, apiClient);
     case "publish-poll-results":
-      return handlePublishPollResults(params, apiClient);
+      return handlePublishPollResults(params);
     case "list-polls":
       return handleListPolls(params, apiClient);
     case "get-poll-import-template":
@@ -800,10 +801,11 @@ async function handleDeleteRoomPolls(
 /**
  * Handle publish poll results
  */
-async function handlePublishPollResults(
-  params: { room_id: string; poll_id: string; session_id?: string },
-  apiClient: DigitalSambaApiClient,
-): Promise<any> {
+async function handlePublishPollResults(params: {
+  room_id: string;
+  poll_id: string;
+  session_id?: string;
+}): Promise<any> {
   const { room_id, poll_id, session_id } = params;
 
   if (!room_id || room_id.trim() === "") {
@@ -830,69 +832,31 @@ async function handlePublishPollResults(
     };
   }
 
-  logger.info("Publishing poll results", {
+  // There is no publish-results endpoint. The client posts to
+  // /sessions/{session}/polls/{poll}/publish-results, which is not routed by the
+  // API at all — confirmed against the backend source, where neither routes/ nor
+  // any controller defines a `publish` action. The call can only ever 404, and
+  // the previous "Session ID is required" refusal was this server's own guard,
+  // never the API's, so the tool never reached the point of finding that out.
+  logger.info("Refusing publish-poll-results: no such API endpoint", {
     roomId: room_id,
     pollId: poll_id,
     sessionId: session_id,
   });
 
-  try {
-    // The API method expects session_id as a required parameter
-    // If not provided, we'll need to get the current session or return an error
-    if (!session_id) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: "Session ID is required to publish poll results. Please provide the session ID.",
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    await apiClient.publishPollResults(poll_id, session_id);
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully published results for poll ${poll_id} in room ${room_id} (session ${session_id})`,
-        },
-      ],
-    };
-  } catch (error) {
-    logger.error("Error publishing poll results", {
-      roomId: room_id,
-      pollId: poll_id,
-      sessionId: session_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    let displayMessage = `Error publishing poll results: ${errorMessage}`;
-
-    if (
-      errorMessage.includes("Poll not found") ||
-      errorMessage.includes("404")
-    ) {
-      displayMessage = `Poll with ID ${poll_id} not found`;
-    } else if (errorMessage.includes("Session not found")) {
-      displayMessage = `Session with ID ${session_id} not found`;
-    } else if (errorMessage.includes("Room not found")) {
-      displayMessage = `Room with ID ${room_id} not found`;
-    }
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: displayMessage,
-        },
-      ],
-      isError: true,
-    };
-  }
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          `Publishing poll results is not supported: the Digital Samba API has no ` +
+          `publish-results endpoint. Poll ${poll_id} in room ${room_id} was not ` +
+          `changed and participants were not shown anything. Results can still be ` +
+          `read with export-poll-results.`,
+      },
+    ],
+    isError: true,
+  };
 }
 
 /**

--- a/src/tools/quiz-management/index.ts
+++ b/src/tools/quiz-management/index.ts
@@ -26,6 +26,7 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { DigitalSambaApiClient } from "../../digital-samba-api.js";
 import logger from "../../logger.js";
 import { getToolAnnotations } from "../../tool-annotations.js";
+import { countOf, verifiedWrite } from "../verified-write.js";
 
 /**
  * Tool definition interface
@@ -1132,22 +1133,46 @@ async function handleImportQuizzes(
 
   logger.info("Importing quizzes from CSV", { room_id });
 
+  // The import endpoint returns 2xx with an empty body whether or not it
+  // created anything, so the count delta is the only proof it did.
+  const before = await countQuizzes(room_id, apiClient);
+
+  return verifiedWrite({
+    describe: `quizzes into room ${room_id}`,
+    verb: "Imported",
+    errorLabel: "importing quizzes",
+    action: () => apiClient.importQuizzes(room_id, csv_content),
+    verify: async () => {
+      const after = await countQuizzes(room_id, apiClient);
+      if (before === undefined || after === undefined) {
+        throw new Error("could not list the room's quizzes");
+      }
+      const created = after - before;
+      return {
+        landed: created > 0,
+        evidence:
+          created > 0
+            ? `room now has ${after} quiz(zes), up from ${before}`
+            : `room still has ${after} quiz(zes); no quiz was created`,
+      };
+    },
+  });
+}
+
+/**
+ * Count the quizzes in a room, or undefined if they cannot be listed.
+ */
+async function countQuizzes(
+  roomId: string,
+  apiClient: DigitalSambaApiClient,
+): Promise<number | undefined> {
   try {
-    await apiClient.importQuizzes(room_id, csv_content);
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Successfully imported quizzes into room ${room_id}`,
-        },
-      ],
-    };
+    return countOf(await apiClient.listQuizzes(roomId));
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.error("Error importing quizzes", { room_id, error: message });
-    return {
-      content: [{ type: "text", text: `Error importing quizzes: ${message}` }],
-      isError: true,
-    };
+    logger.warn("Could not count quizzes for import verification", {
+      roomId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
   }
 }

--- a/src/tools/recording-tools-adapter.ts
+++ b/src/tools/recording-tools-adapter.ts
@@ -206,14 +206,19 @@ export async function executeRecordingTool(
       };
 
     case "update-recording":
-      // Update recording not supported in base API
+      // The API has no recording-update endpoint. This has always returned a
+      // plain message, which a client reads as a successful call — so a rename
+      // looked like it worked. Mark it as the failure it is.
       return {
         content: [
           {
             type: "text",
-            text: `Recording update not supported`,
+            text:
+              `Renaming recordings is not supported: the Digital Samba API has no ` +
+              `recording-update endpoint. Recording ${args.recording_id} was not changed.`,
           },
         ],
+        isError: true,
       };
 
     case "get-recordings": {

--- a/src/tools/role-management/index.ts
+++ b/src/tools/role-management/index.ts
@@ -332,12 +332,20 @@ async function handleUpdateRole(
   logger.info("Updating role", { roleId, updates });
 
   try {
-    // Normalize boolean values in permissions (Claude sometimes sends 0/1)
-    const normalizedUpdates = { ...updates };
+    // The API takes display_name; sending the tool's camelCase displayName
+    // through unmapped made it silently ignore the rename while still
+    // returning 200, so the tool reported a change that never happened.
+    // create-role has always mapped it — update-role did not.
+    const { displayName, ...rest } = updates;
+    const normalizedUpdates: Record<string, unknown> = {
+      ...rest,
+      ...(displayName !== undefined && { display_name: displayName }),
+    };
+
     if (normalizedUpdates.permissions) {
       const normalizedPermissions: Record<string, boolean> = {};
       for (const [key, value] of Object.entries(
-        normalizedUpdates.permissions,
+        normalizedUpdates.permissions as Record<string, unknown>,
       )) {
         const normalized = normalizeBoolean(value);
         if (normalized !== undefined) {
@@ -349,13 +357,23 @@ async function handleUpdateRole(
 
     const role = await apiClient.updateRole(roleId, normalizedUpdates);
 
-    const updatedFields = Object.keys(updates).join(", ");
+    // Report what the API says the role now is, not what we asked it to be.
+    const applied: string[] = [];
+    if (displayName !== undefined) {
+      applied.push(
+        role.display_name === displayName
+          ? "displayName"
+          : `displayName (NOT applied — still "${role.display_name}")`,
+      );
+    }
+    if (rest.description !== undefined) applied.push("description");
+    if (rest.permissions !== undefined) applied.push("permissions");
 
     return {
       content: [
         {
           type: "text",
-          text: `Successfully updated role "${role.display_name}". Updated fields: ${updatedFields}`,
+          text: `Updated role "${role.display_name}" (${roleId}). Fields: ${applied.join(", ")}`,
         },
       ],
     };

--- a/src/tools/room-management/index.ts
+++ b/src/tools/room-management/index.ts
@@ -61,6 +61,12 @@ export function registerRoomTools(): Tool[] {
             type: "string",
             description: "External identifier for the room",
           },
+          tags: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Room tags. These are the only way to make a room targetable by delete-rooms-by-tag; tags cannot be added later, as the update-room endpoint does not accept them.",
+          },
           max_participants: {
             type: "number",
             minimum: 2,
@@ -1017,13 +1023,22 @@ export async function executeRoomTool(
           delete_library,
         });
         await client.deleteRoomsByTag({ tags, ...options });
-        logger.info("Rooms deleted by tag successfully", { tags });
+        logger.info("Room deletion by tag accepted", { tags });
 
+        // The endpoint answers 202 with an empty body: the deletion is
+        // asynchronous and the API reports no count. Claiming rooms were
+        // deleted would be a guess, and an unmatched tag is indistinguishable
+        // from a matched one — which matters a great deal for a bulk delete.
+        const label = Array.isArray(tags) ? tags.join(", ") : tags;
         return {
           content: [
             {
               type: "text",
-              text: `Successfully deleted rooms matching tag(s): ${Array.isArray(tags) ? tags.join(", ") : tags}`,
+              text:
+                `The API accepted a request to delete all rooms tagged: ${label}. ` +
+                `Deletion is asynchronous and the API returns no count, so this ` +
+                `does not confirm that any room matched or was deleted. ` +
+                `Use list-rooms to check the result.`,
             },
           ],
         };

--- a/src/tools/verified-write.ts
+++ b/src/tools/verified-write.ts
@@ -1,0 +1,219 @@
+/**
+ * Verified write helper
+ *
+ * Write tools used to report a fixed success string whenever the API returned
+ * any 2xx. That is not evidence: several Digital Samba write endpoints accept a
+ * request, return 200 with an empty body, and do nothing (`import-polls` and
+ * `send-chat-message` both shipped in v1.1.0 behaving this way). A tool that
+ * says "Successfully imported polls" when nothing was imported is worse than
+ * one that errors, because the caller acts on the lie.
+ *
+ * This module gives write handlers one code path that reports only what was
+ * actually established:
+ *
+ * - the API response body, when it carries evidence (an id, a count);
+ * - a read-back, when one is cheap and a silent no-op is plausible;
+ * - otherwise, plainly, that the request was accepted and nothing more.
+ *
+ * @module tools/verified-write
+ */
+import logger from "../logger.js";
+
+/**
+ * Result of reading state back after a write.
+ */
+export interface VerifyOutcome {
+  /** Whether the read-back proves the write actually landed */
+  landed: boolean;
+  /** What the read-back showed, e.g. "room now has 5 polls (was 2)" */
+  evidence: string;
+}
+
+/**
+ * Standard MCP tool result shape used by the tool handlers.
+ */
+export interface ToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+export interface VerifiedWriteOptions<T> {
+  /**
+   * Field name → value pairs that must be present. The first missing one
+   * short-circuits with the same "<field> is required." message the handlers
+   * used before.
+   */
+  required?: Record<string, unknown>;
+  /**
+   * Noun phrase naming what is being written, e.g. `polls into room abc`. Reads
+   * after the verb on success and after "this request for" when unverified, so
+   * keep it a noun phrase rather than a clause.
+   */
+  describe: string;
+  /** The write itself. Resolves to the parsed API response body. */
+  action: () => Promise<T>;
+  /**
+   * Optional read-back, run after a successful write. Supply this wherever a
+   * silent no-op is plausible and a read endpoint exists.
+   */
+  verify?: (result: T) => Promise<VerifyOutcome>;
+  /** Verb used in messages, e.g. `Imported`. */
+  verb: string;
+  /** Label used in error text and logs, e.g. `importing polls`. */
+  errorLabel: string;
+}
+
+/**
+ * Pull whatever identifying evidence the response body carries.
+ *
+ * Returns undefined when the body is empty or has nothing useful — which is the
+ * common case for these endpoints and precisely why `verify` exists.
+ */
+export function extractEvidence(result: unknown): string | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const body = result as Record<string, unknown>;
+
+  const id = body.id ?? body.uuid ?? body.external_id;
+  if (typeof id === "string" || typeof id === "number") {
+    return `id ${id}`;
+  }
+
+  if (Array.isArray(body.data)) {
+    return `${body.data.length} record(s) returned`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Count the items in a list response.
+ *
+ * List endpoints return either a bare array or a paginated `{ data: [...] }`
+ * object, so read-backs that compare counts must accept both.
+ *
+ * @returns the item count, or undefined when the value is neither shape
+ */
+export function countOf(value: unknown): number | undefined {
+  if (Array.isArray(value)) return value.length;
+  if (value && typeof value === "object") {
+    const data = (value as { data?: unknown }).data;
+    if (Array.isArray(data)) return data.length;
+  }
+  return undefined;
+}
+
+/**
+ * Describe the outcome of an unverified write.
+ *
+ * Reports the response body's evidence when it carries any, and otherwise says
+ * plainly that the request was accepted and nothing more — never "Successfully
+ * X", which a no-op endpoint would earn just as easily as a real write.
+ *
+ * Exported for handlers that keep their own error handling and only need the
+ * success wording.
+ *
+ * @param result - the parsed API response body
+ * @param verb - past-tense verb, e.g. `Connected`
+ * @param describe - noun phrase naming the target, e.g. `room abc`
+ */
+export function describeWriteResult(
+  result: unknown,
+  verb: string,
+  describe: string,
+): string {
+  const evidence = extractEvidence(result);
+  return evidence
+    ? `${verb} ${describe} (${evidence}).`
+    : `The API accepted the request (${verb} ${describe}) but returned no ` +
+        `confirmation body, so the effect is not verified here. Read the ` +
+        `state back if it matters.`;
+}
+
+/**
+ * Run a write and report only what can actually be substantiated.
+ *
+ * @param options - see {@link VerifiedWriteOptions}
+ * @returns an MCP tool result; `isError` is set when a read-back proves the
+ *          write did not land, so a no-op can never read as success
+ */
+export async function verifiedWrite<T>(
+  options: VerifiedWriteOptions<T>,
+): Promise<ToolResult> {
+  const { required, describe, action, verify, verb, errorLabel } = options;
+
+  for (const [field, value] of Object.entries(required ?? {})) {
+    if (value === undefined || value === null || value === "") {
+      return {
+        content: [{ type: "text", text: `${field} is required.` }],
+        isError: true,
+      };
+    }
+  }
+
+  let result: T;
+  try {
+    result = await action();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`Error ${errorLabel}`, { error: message });
+    return {
+      content: [{ type: "text", text: `Error ${errorLabel}: ${message}` }],
+      isError: true,
+    };
+  }
+
+  if (!verify) {
+    // Nothing to read back. Say what happened — the request was accepted — and
+    // do not imply the effect was confirmed.
+    return {
+      content: [
+        { type: "text", text: describeWriteResult(result, verb, describe) },
+      ],
+    };
+  }
+
+  let outcome: VerifyOutcome;
+  try {
+    outcome = await verify(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`Read-back failed after ${errorLabel}`, { error: message });
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `The API accepted the request to ${describe}, but reading the state ` +
+            `back to confirm it failed: ${message}. The write is unverified.`,
+        },
+      ],
+    };
+  }
+
+  if (!outcome.landed) {
+    logger.error(`Write reported success but did not land: ${errorLabel}`, {
+      evidence: outcome.evidence,
+    });
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `The API returned success for ${describe}, but reading the state back ` +
+            `shows it had no effect (${outcome.evidence}). Nothing was changed. ` +
+            `This is an API-side failure, not a rejected request.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `${verb} ${describe} — confirmed by read-back (${outcome.evidence}).`,
+      },
+    ],
+  };
+}

--- a/src/tools/webhook-management/index.ts
+++ b/src/tools/webhook-management/index.ts
@@ -478,15 +478,26 @@ async function handleUpdateWebhook(
   logger.info("Updating webhook", { webhookId, updates: Object.keys(updates) });
 
   try {
-    const webhook = await apiClient.updateWebhook(webhookId, updates);
+    // The API takes authorization_header; passing the tool's camelCase
+    // authorizationHeader through unmapped made it silently ignore the change
+    // while still returning 200. create-webhook has always mapped it.
+    const { authorizationHeader, ...rest } = updates;
+    const payload: Record<string, unknown> = {
+      ...rest,
+      ...(authorizationHeader !== undefined && {
+        authorization_header: authorizationHeader,
+      }),
+    };
 
-    const updatedFields = Object.keys(updates).join(", ");
+    const webhook = await apiClient.updateWebhook(webhookId, payload);
+
+    const updatedFields = Object.keys(payload).join(", ");
 
     return {
       content: [
         {
           type: "text",
-          text: `Successfully updated webhook "${webhook.name || "Unnamed"}". Updated fields: ${updatedFields}`,
+          text: `Updated webhook "${webhook.name || "Unnamed"}" (${webhookId}). Fields: ${updatedFields}`,
         },
       ],
     };

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -14,6 +14,8 @@ export interface Library {
 
 export interface LibraryFolder {
   id: string;
+  name?: string;
+  parent_id?: string;
   external_id?: string;
   description?: string;
   created_at: string;
@@ -26,4 +28,6 @@ export interface LibraryFile {
   type: string;
   size: number;
   created_at: string;
+  /** Present on webapp entries (type `youtube`, `custom`, …); absent on stored files. */
+  url?: string;
 }

--- a/tests/unit/analytics-tools-execution.test.ts
+++ b/tests/unit/analytics-tools-execution.test.ts
@@ -108,9 +108,15 @@ describe('Analytics Tools Execution', () => {
           mockApiClient
         );
         
+        // `period` is never forwarded: the API has no such parameter. It is
+        // translated into the date range the API does accept.
         expect(mockAnalyticsResource.getRoomAnalytics).toHaveBeenCalledWith(
           'room-123',
-          { room_id: 'room-123', period: 'month' }
+          {
+            room_id: 'room-123',
+            date_start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+            date_end: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
+          }
         );
         
         expect(result.content[0].text).toContain('room-123');
@@ -203,9 +209,10 @@ describe('Analytics Tools Execution', () => {
         );
         
         expect(mockAnalyticsResource.getTeamAnalytics).toHaveBeenCalledWith({
-          period: 'week'
+          date_start: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          date_end: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
         });
-        
+
         expect(result.content[0].text).toContain('usage');
       });
     });
@@ -225,10 +232,40 @@ describe('Analytics Tools Execution', () => {
           mockApiClient
         );
         
+        // An explicit date wins: `period` does not fill in, and is not sent.
         expect(mockAnalyticsResource.getTeamAnalytics).toHaveBeenCalledWith({
-          date_start: '2025-01-01',
-          period: 'month'
+          date_start: '2025-01-01'
         });
+      });
+
+      it('should translate period into a date range of the right span', async () => {
+        mockAnalyticsResource.getTeamAnalytics.mockResolvedValueOnce({});
+
+        await executeAnalyticsTool(
+          'get-team-analytics',
+          { period: 'week' },
+          mockApiClient
+        );
+
+        const filters = mockAnalyticsResource.getTeamAnalytics.mock.calls[0][0];
+        const spanDays =
+          (Date.parse(filters.date_end) - Date.parse(filters.date_start)) /
+          86_400_000;
+
+        expect(spanDays).toBe(7);
+        expect(filters.period).toBeUndefined();
+      });
+
+      it('should leave the range unbounded for an unrecognised period', async () => {
+        mockAnalyticsResource.getTeamAnalytics.mockResolvedValueOnce({});
+
+        await executeAnalyticsTool(
+          'get-team-analytics',
+          { period: 'fortnight' },
+          mockApiClient
+        );
+
+        expect(mockAnalyticsResource.getTeamAnalytics).toHaveBeenCalledWith({});
       });
     });
 

--- a/tests/unit/no-such-endpoint.test.ts
+++ b/tests/unit/no-such-endpoint.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tools whose backing API endpoint does not exist.
+ *
+ * Reading the API's own source (webapp-api-laravel) after the 2026-08-13 smoke
+ * sweep turned up two tools that could never have worked, and said otherwise:
+ *
+ * - `publish-poll-results` posts to /sessions/{s}/polls/{p}/publish-results,
+ *   which is not routed at all — no `publish` action exists in the backend. The
+ *   "Session ID is required" refusal callers saw was this server's own guard, so
+ *   the request was never actually sent and the 404 never surfaced.
+ * - `copy-library-content` had no copy endpoint to call, so for a file it built
+ *   a placeholder with createLibraryFile and reported "Successfully copied file".
+ *   Nothing was copied, for any file type. A webapp is the one case that can be
+ *   genuinely duplicated, because its URL fully describes it.
+ *
+ * Both now report the truth. These tests pin that, so a future refactor cannot
+ * quietly restore the false success.
+ */
+import { executePollTool } from "../../src/tools/poll-management/index.js";
+import { executeLibraryTool } from "../../src/tools/library-management/index.js";
+
+jest.mock("../../src/logger.js");
+
+const textOf = (result: any): string => result.content[0].text;
+
+describe("publish-poll-results", () => {
+  it("reports failure instead of pretending to publish", async () => {
+    const apiClient: any = {
+      publishPollResults: jest.fn(),
+    };
+
+    const result = await executePollTool(
+      "publish-poll-results",
+      { room_id: "r1", poll_id: "p1", session_id: "s1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("not supported");
+    expect(textOf(result)).toContain("p1");
+    // Never call the dead path — a 404 would be reported as a transport error
+    // rather than as the missing feature it is.
+    expect(apiClient.publishPollResults).not.toHaveBeenCalled();
+  });
+
+  it("still validates its inputs first", async () => {
+    const result = await executePollTool(
+      "publish-poll-results",
+      { room_id: "r1", poll_id: "", session_id: "s1" },
+      {} as any,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("Poll ID is required");
+  });
+});
+
+describe("copy-library-content", () => {
+  const copy = (params: Record<string, unknown>, apiClient: any) =>
+    executeLibraryTool(
+      "copy-library-content",
+      {
+        sourceLibraryId: "lib-a",
+        targetLibraryId: "lib-b",
+        contentType: "file",
+        contentId: "f1",
+        ...params,
+      },
+      apiClient,
+    );
+
+  it("refuses to 'copy' a stored file rather than creating an empty placeholder", async () => {
+    const apiClient: any = {
+      getLibraryFile: jest.fn().mockResolvedValue({
+        id: "f1",
+        name: "slides.pdf",
+        type: "application/pdf",
+        size: 1024,
+      }),
+      createLibraryFile: jest.fn(),
+    };
+
+    const result = await copy({}, apiClient);
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("slides.pdf");
+    expect(textOf(result)).toContain("not supported");
+    expect(apiClient.createLibraryFile).not.toHaveBeenCalled();
+  });
+
+  it("genuinely duplicates a webapp, preserving its type and url", async () => {
+    const apiClient: any = {
+      getLibraryFile: jest.fn().mockResolvedValue({
+        id: "f1",
+        name: "Intro video",
+        type: "youtube",
+        size: 0,
+        url: "https://www.youtube.com/watch?v=abc123",
+      }),
+      createWebapp: jest.fn().mockResolvedValue({
+        id: "f2",
+        name: "Intro video copy",
+        type: "youtube",
+        url: "https://www.youtube.com/watch?v=abc123",
+        status: "completed",
+        created_at: "2026-08-14T00:00:00Z",
+      }),
+    };
+
+    const result = await copy({ newName: "Intro video copy" }, apiClient);
+
+    expect(result.isError).toBeUndefined();
+    expect(apiClient.createWebapp).toHaveBeenCalledWith("lib-b", {
+      url: "https://www.youtube.com/watch?v=abc123",
+      name: "Intro video copy",
+    });
+    expect(textOf(result)).toContain("youtube");
+    expect(textOf(result)).toContain("https://www.youtube.com/watch?v=abc123");
+  });
+
+  it("passes the target folder through when duplicating a webapp", async () => {
+    const apiClient: any = {
+      getLibraryFile: jest.fn().mockResolvedValue({
+        id: "f1",
+        name: "Intro video",
+        type: "youtube",
+        size: 0,
+        url: "https://example.test/v",
+      }),
+      createWebapp: jest.fn().mockResolvedValue({
+        id: "f2",
+        name: "Intro video",
+        type: "youtube",
+        url: "https://example.test/v",
+        status: "completed",
+        created_at: "2026-08-14T00:00:00Z",
+      }),
+    };
+
+    await copy({ targetFolderId: "fold-1" }, apiClient);
+
+    expect(apiClient.createWebapp).toHaveBeenCalledWith("lib-b", {
+      url: "https://example.test/v",
+      name: "Intro video",
+      folder_id: "fold-1",
+    });
+  });
+
+  it("does not call a folder copy a copy", async () => {
+    const apiClient: any = {
+      getLibraryFolder: jest.fn().mockResolvedValue({
+        id: "fold-1",
+        name: "Decks",
+        created_at: "2026-08-14T00:00:00Z",
+      }),
+      createLibraryFolder: jest.fn().mockResolvedValue({
+        id: "fold-2",
+        name: "Decks copy",
+        created_at: "2026-08-14T00:00:00Z",
+      }),
+    };
+
+    const result = await copy(
+      { contentType: "folder", contentId: "fold-1", newName: "Decks copy" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("empty folder");
+    expect(textOf(result)).toContain("NOT copied");
+  });
+});

--- a/tests/unit/pre-release-fixes.test.ts
+++ b/tests/unit/pre-release-fixes.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the fixes made after the 2026-08-13 smoke sweep, before tagging.
+ *
+ * Each of these was a tool telling the caller something that was not true:
+ * a bulk delete reporting confirmed deletion of an asynchronous, uncounted
+ * operation; a phone bridge reporting a connection the account cannot make.
+ */
+import { executePollTool } from "../../src/tools/poll-management/index.js";
+import { executeRoomTool } from "../../src/tools/room-management/index.js";
+import { executeLiveSessionTool } from "../../src/tools/live-session-controls/index.js";
+import { DigitalSambaApiClient } from "../../src/digital-samba-api.js";
+import { getApiKeyFromRequest } from "../../src/auth.js";
+
+// executeRoomTool builds its own client from the request, so the class has to
+// be mocked rather than injected.
+jest.mock("../../src/digital-samba-api");
+jest.mock("../../src/auth");
+
+const textOf = (result: any): string => result.content[0].text;
+
+const roomToolCtx = {
+  request: { sessionId: "test-session" },
+  options: { apiUrl: "https://api.example.test/api/v1" },
+};
+
+describe("list-polls", () => {
+  it("lists a room's polls", async () => {
+    const apiClient: any = {
+      getPolls: jest.fn().mockResolvedValue([{ id: "p1", question: "Q?" }]),
+    };
+
+    const result = await executePollTool(
+      "list-polls",
+      { room_id: "r1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("p1");
+    expect(textOf(result)).toContain("1 poll(s)");
+  });
+
+  it("handles the paginated envelope as well as a bare array", async () => {
+    const apiClient: any = {
+      getPolls: jest.fn().mockResolvedValue({ data: [{ id: "p1" }] }),
+    };
+
+    const result = await executePollTool(
+      "list-polls",
+      { room_id: "r1" },
+      apiClient,
+    );
+
+    expect(textOf(result)).toContain("p1");
+  });
+
+  it("says so when there are none", async () => {
+    const apiClient: any = { getPolls: jest.fn().mockResolvedValue([]) };
+
+    const result = await executePollTool(
+      "list-polls",
+      { room_id: "r1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("No polls found");
+  });
+});
+
+describe("delete-rooms-by-tag", () => {
+  let mockApiClient: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiClient = { deleteRoomsByTag: jest.fn().mockResolvedValue({}) };
+    (
+      DigitalSambaApiClient as jest.MockedClass<typeof DigitalSambaApiClient>
+    ).mockImplementation(() => mockApiClient);
+    (getApiKeyFromRequest as jest.Mock).mockReturnValue("test-api-key");
+  });
+
+  it("does not claim rooms were deleted", async () => {
+    // The endpoint answers 202 with an empty body: asynchronous, no count, and
+    // an unmatched tag looks identical to a matched one.
+    const result = await executeRoomTool(
+      "delete-rooms-by-tag",
+      { tags: ["obsolete"] },
+      roomToolCtx.request,
+      roomToolCtx.options,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("accepted");
+    expect(textOf(result)).toContain("does not confirm");
+    expect(textOf(result)).not.toMatch(/Successfully deleted/i);
+  });
+
+  it("still requires at least one tag", async () => {
+    const result = await executeRoomTool(
+      "delete-rooms-by-tag",
+      { tags: [] },
+      roomToolCtx.request,
+      roomToolCtx.options,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(mockApiClient.deleteRoomsByTag).not.toHaveBeenCalled();
+  });
+
+  it("exposes tags on create-room, the only way to set them", async () => {
+    const { registerRoomTools } = await import(
+      "../../src/tools/room-management/index.js"
+    );
+    const createRoom = registerRoomTools().find(
+      (t) => t.name === "create-room",
+    );
+    expect(createRoom?.inputSchema.properties).toHaveProperty("tags");
+  });
+});
+
+describe("connect-phone", () => {
+  it("refuses when the room has no telephony, instead of the API's false success", async () => {
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ telephony_enabled: false }),
+      connectPhone: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executeLiveSessionTool(
+      "connect-phone",
+      { room_id: "r1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("Telephony is not enabled");
+    // The point of the guard: don't make a call the API will wrongly bless.
+    expect(apiClient.connectPhone).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when telephony is enabled", async () => {
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ telephony_enabled: true }),
+      connectPhone: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executeLiveSessionTool(
+      "connect-phone",
+      { room_id: "r1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(apiClient.connectPhone).toHaveBeenCalledWith("r1");
+  });
+
+  it("proceeds when the room cannot be read, rather than blocking on the check", async () => {
+    const apiClient: any = {
+      getRoom: jest.fn().mockRejectedValue(new Error("forbidden")),
+      connectPhone: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executeLiveSessionTool(
+      "connect-phone",
+      { room_id: "r1" },
+      apiClient,
+    );
+
+    expect(apiClient.connectPhone).toHaveBeenCalled();
+    expect(result.isError).toBeUndefined();
+  });
+});

--- a/tests/unit/recording-tools-adapter.test.ts
+++ b/tests/unit/recording-tools-adapter.test.ts
@@ -73,7 +73,11 @@ describe("Recording Tools Adapter", () => {
         mockClient
       );
 
-      expect(result.content[0].text).toBe("Recording update not supported");
+      // Must be an error: the rename did not happen, so a plain message
+      // would read to the client as a successful update.
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("not supported");
+      expect(result.content[0].text).toContain("rec123");
     });
 
     it("should get recordings", async () => {

--- a/tests/unit/recordings.test.ts
+++ b/tests/unit/recordings.test.ts
@@ -281,13 +281,17 @@ describe('Recording Tools', () => {
     });
 
     describe('update-recording', () => {
-      it('should indicate update is not supported', async () => {
+      it('should report the unsupported update as an error, not a success', async () => {
+        // Previously this returned a plain message with no isError, so a
+        // client read the failed rename as a successful call.
         const result = await executeRecordingTool('update-recording', {
           recording_id: 'test-recording-id',
           name: 'New Recording Name'
         }, mockApiClient);
 
-        expect(result.content[0].text).toBe('Recording update not supported');
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('not supported');
+        expect(result.content[0].text).toContain('was not changed');
       });
     });
 

--- a/tests/unit/update-field-mapping.test.ts
+++ b/tests/unit/update-field-mapping.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for the silent-drop bugs found during the 2026-08-13 sweep.
+ *
+ * update-role and update-webhook took their params with a rest spread and
+ * handed them to the API unchanged. The API expects snake_case, so the
+ * camelCase-only fields — displayName, authorizationHeader — were unknown
+ * fields: ignored, still 200, and the tool then reported them as updated.
+ * Their create-* counterparts had always mapped these fields, which is why the
+ * bug only ever showed on update.
+ *
+ * Verified live on dev: renaming a role via update-role left the display name
+ * unchanged while permissions in the same call did apply.
+ */
+import { executeRoleTool } from "../../src/tools/role-management/index.js";
+import { executeWebhookTool } from "../../src/tools/webhook-management/index.js";
+
+const textOf = (result: any): string => result.content[0].text;
+
+describe("update-role", () => {
+  it("sends display_name, not displayName", async () => {
+    const apiClient: any = {
+      updateRole: jest
+        .fn()
+        .mockResolvedValue({ id: "r1", display_name: "New Name" }),
+    };
+
+    await executeRoleTool(
+      "update-role",
+      { roleId: "r1", displayName: "New Name" },
+      apiClient,
+    );
+
+    const payload = apiClient.updateRole.mock.calls[0][1];
+    expect(payload).toHaveProperty("display_name", "New Name");
+    expect(payload).not.toHaveProperty("displayName");
+  });
+
+  it("flags the rename as not applied when the API ignores it", async () => {
+    // The exact live failure: 200 back, but the role still has the old name.
+    const apiClient: any = {
+      updateRole: jest
+        .fn()
+        .mockResolvedValue({ id: "r1", display_name: "Old Name" }),
+    };
+
+    const result = await executeRoleTool(
+      "update-role",
+      { roleId: "r1", displayName: "New Name" },
+      apiClient,
+    );
+
+    expect(textOf(result)).toContain("NOT applied");
+    expect(textOf(result)).toContain("Old Name");
+  });
+
+  it("still maps permissions and normalises their booleans", async () => {
+    const apiClient: any = {
+      updateRole: jest
+        .fn()
+        .mockResolvedValue({ id: "r1", display_name: "Role" }),
+    };
+
+    await executeRoleTool(
+      "update-role",
+      { roleId: "r1", permissions: { broadcast: 1, screenshare: 0 } },
+      apiClient,
+    );
+
+    expect(apiClient.updateRole.mock.calls[0][1].permissions).toEqual({
+      broadcast: true,
+      screenshare: false,
+    });
+  });
+});
+
+describe("update-webhook", () => {
+  it("sends authorization_header, not authorizationHeader", async () => {
+    const apiClient: any = {
+      updateWebhook: jest.fn().mockResolvedValue({ id: "w1", name: "hook" }),
+    };
+
+    await executeWebhookTool(
+      "update-webhook",
+      { webhookId: "w1", authorizationHeader: "Bearer xyz" },
+      apiClient,
+    );
+
+    const payload = apiClient.updateWebhook.mock.calls[0][1];
+    expect(payload).toHaveProperty("authorization_header", "Bearer xyz");
+    expect(payload).not.toHaveProperty("authorizationHeader");
+  });
+
+  it("passes through the fields whose names already match", async () => {
+    const apiClient: any = {
+      updateWebhook: jest.fn().mockResolvedValue({ id: "w1", name: "hook" }),
+    };
+
+    await executeWebhookTool(
+      "update-webhook",
+      {
+        webhookId: "w1",
+        endpoint: "https://example.com/hook",
+        events: ["session_started"],
+      },
+      apiClient,
+    );
+
+    expect(apiClient.updateWebhook.mock.calls[0][1]).toEqual({
+      endpoint: "https://example.com/hook",
+      events: ["session_started"],
+    });
+  });
+});

--- a/tests/unit/verified-writes.test.ts
+++ b/tests/unit/verified-writes.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Regression tests for the false-success bugs found on 2026-08-13.
+ *
+ * `import-polls` and `send-chat-message` both shipped in v1.1.0 reporting
+ * "Successfully imported" / "Sent chat message" while the API accepted the
+ * request and did nothing. The tools trusted any 2xx. These tests pin the rule
+ * that replaced that: a write is only reported as done when something actually
+ * substantiates it.
+ */
+import {
+  countOf,
+  describeWriteResult,
+  extractEvidence,
+  verifiedWrite,
+} from "../../src/tools/verified-write.js";
+import { executePollTool } from "../../src/tools/poll-management/index.js";
+import { executeQuizTool } from "../../src/tools/quiz-management/index.js";
+import { executeCommunicationTool } from "../../src/tools/communication-management/index.js";
+import { executeLiveSessionTool } from "../../src/tools/live-session-controls/index.js";
+
+const textOf = (result: any): string => result.content[0].text;
+
+describe("verifiedWrite", () => {
+  it("reports a no-op as an error when the read-back shows nothing changed", async () => {
+    const result = await verifiedWrite({
+      describe: "polls into room r1",
+      verb: "Imported",
+      errorLabel: "importing polls",
+      // The API's no-op: 200 with an empty body.
+      action: async () => ({}),
+      verify: async () => ({ landed: false, evidence: "still 0 polls" }),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("no effect");
+    expect(textOf(result)).not.toMatch(/^Imported/);
+  });
+
+  it("confirms a write when the read-back proves it landed", async () => {
+    const result = await verifiedWrite({
+      describe: "polls into room r1",
+      verb: "Imported",
+      errorLabel: "importing polls",
+      action: async () => ({}),
+      verify: async () => ({ landed: true, evidence: "3 polls, up from 0" }),
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("confirmed by read-back");
+    expect(textOf(result)).toContain("3 polls, up from 0");
+  });
+
+  it("does not claim success when there is no read-back and no response body", async () => {
+    const result = await verifiedWrite({
+      describe: "room r1",
+      verb: "Connected the phone bridge for",
+      errorLabel: "connecting phone",
+      action: async () => ({}),
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("not verified");
+    expect(textOf(result)).not.toContain("Successfully");
+  });
+
+  it("reports the response body's evidence when it carries any", async () => {
+    const result = await verifiedWrite({
+      describe: "a question in room r1",
+      verb: "Created",
+      errorLabel: "creating question",
+      action: async () => ({ id: "q-77" }),
+    });
+
+    expect(textOf(result)).toContain("id q-77");
+  });
+
+  it("treats a failed read-back as unverified rather than as failure", async () => {
+    const result = await verifiedWrite({
+      describe: "a chat message to room r1",
+      verb: "Sent",
+      errorLabel: "sending chat message",
+      action: async () => ({}),
+      verify: async () => {
+        throw new Error("export unavailable");
+      },
+    });
+
+    // The write may well have landed — only the confirmation failed, so this
+    // must not be reported as an error.
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("unverified");
+  });
+
+  it("surfaces a rejected write as an error", async () => {
+    const result = await verifiedWrite({
+      describe: "a question in room r1",
+      verb: "Created",
+      errorLabel: "creating question",
+      action: async () => {
+        throw new Error("This room is not active");
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("This room is not active");
+  });
+
+  it("rejects missing required fields before calling the API", async () => {
+    const action = jest.fn();
+    const result = await verifiedWrite({
+      required: { roomId: "" },
+      describe: "a question",
+      verb: "Created",
+      errorLabel: "creating question",
+      action,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toBe("roomId is required.");
+    expect(action).not.toHaveBeenCalled();
+  });
+});
+
+describe("countOf", () => {
+  it("counts bare arrays and paginated envelopes alike", () => {
+    expect(countOf([1, 2, 3])).toBe(3);
+    expect(countOf({ data: [1, 2] })).toBe(2);
+    expect(countOf([])).toBe(0);
+  });
+
+  it("returns undefined for shapes it cannot count", () => {
+    expect(countOf(undefined)).toBeUndefined();
+    expect(countOf({ total: 5 })).toBeUndefined();
+  });
+});
+
+describe("extractEvidence", () => {
+  it("finds an id when the body carries one", () => {
+    expect(extractEvidence({ id: "abc" })).toBe("id abc");
+    expect(extractEvidence({ uuid: 12 })).toBe("id 12");
+  });
+
+  it("finds nothing in an empty body", () => {
+    expect(extractEvidence({})).toBeUndefined();
+    expect(extractEvidence(undefined)).toBeUndefined();
+  });
+});
+
+describe("describeWriteResult", () => {
+  it("never claims success for an empty body", () => {
+    const text = describeWriteResult({}, "Connected", "room r1");
+    expect(text).toContain("not verified");
+    expect(text).not.toContain("Successfully");
+  });
+});
+
+describe("import-polls", () => {
+  const csv = "question,option1\nA,B\n";
+
+  it("reports an error when the API accepts the CSV but creates nothing", async () => {
+    // Exactly the reproduced bug: 2xx, empty body, poll count unchanged.
+    const apiClient: any = {
+      getPolls: jest.fn().mockResolvedValue([]),
+      importPolls: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executePollTool(
+      "import-polls",
+      { room_id: "r1", csv_content: csv },
+      apiClient,
+    );
+
+    expect(apiClient.importPolls).toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("no effect");
+    expect(textOf(result)).not.toContain("Successfully imported");
+  });
+
+  it("confirms the import with the actual count delta", async () => {
+    const apiClient: any = {
+      getPolls: jest
+        .fn()
+        .mockResolvedValueOnce([{ id: "p1" }])
+        .mockResolvedValueOnce([{ id: "p1" }, { id: "p2" }, { id: "p3" }]),
+      importPolls: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executePollTool(
+      "import-polls",
+      { room_id: "r1", csv_content: csv },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("3 poll(s), up from 1");
+  });
+
+  it("does not claim failure when the polls cannot be listed", async () => {
+    const apiClient: any = {
+      getPolls: jest.fn().mockRejectedValue(new Error("forbidden")),
+      importPolls: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executePollTool(
+      "import-polls",
+      { room_id: "r1", csv_content: csv },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("unverified");
+  });
+});
+
+describe("import-quizzes", () => {
+  it("reports an error when the API accepts the CSV but creates nothing", async () => {
+    const apiClient: any = {
+      listQuizzes: jest.fn().mockResolvedValue({ data: [] }),
+      importQuizzes: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executeQuizTool(
+      "import-quizzes",
+      { room_id: "r1", csv_content: "a,b\n1,2\n" },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("no effect");
+  });
+
+  it("confirms the import with the actual count delta", async () => {
+    const apiClient: any = {
+      listQuizzes: jest
+        .fn()
+        .mockResolvedValueOnce({ data: [] })
+        .mockResolvedValueOnce({ data: [{ id: "q1" }] }),
+      importQuizzes: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executeQuizTool(
+      "import-quizzes",
+      { room_id: "r1", csv_content: "a,b\n1,2\n" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("1 quiz(zes), up from 0");
+  });
+});
+
+describe("send-chat-message", () => {
+  it("reports an error when the message never reaches a persisted room", async () => {
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ chat_persistence_enabled: true }),
+      sendChatMessage: jest.fn().mockResolvedValue({}),
+      exportChatMessages: jest.fn().mockResolvedValue("[]"),
+    };
+
+    const result = await executeCommunicationTool(
+      "send-chat-message",
+      { roomId: "r1", message: "hello" },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("absent from the room's chat export");
+  });
+
+  it("confirms delivery when the message appears in the export", async () => {
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ chat_persistence_enabled: true }),
+      sendChatMessage: jest.fn().mockResolvedValue({}),
+      exportChatMessages: jest
+        .fn()
+        .mockResolvedValue(JSON.stringify([{ message: "hello" }])),
+    };
+
+    const result = await executeCommunicationTool(
+      "send-chat-message",
+      { roomId: "r1", message: "hello" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("confirmed by read-back");
+  });
+
+  it("does not verify against the export when the room does not persist chat", async () => {
+    // Without persistence an empty export proves nothing, so claiming failure
+    // would be as wrong as claiming delivery.
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ chat_persistence_enabled: false }),
+      sendChatMessage: jest.fn().mockResolvedValue({}),
+      exportChatMessages: jest.fn().mockResolvedValue("[]"),
+    };
+
+    const result = await executeCommunicationTool(
+      "send-chat-message",
+      { roomId: "r1", message: "hello" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("not verified");
+    expect(apiClient.exportChatMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe("create-question", () => {
+  const participant = { name: "Ada", external_id: "ada-1" };
+
+  it("recovers the question id the create endpoint does not return", async () => {
+    const apiClient: any = {
+      createQuestion: jest.fn().mockResolvedValue({}),
+      exportQA: jest
+        .fn()
+        .mockResolvedValue(
+          JSON.stringify([{ id: "q-42", question: "Is this on?" }]),
+        ),
+    };
+
+    const result = await executeCommunicationTool(
+      "create-question",
+      { roomId: "r1", question: "Is this on?", participant },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("question id q-42");
+  });
+
+  it("reports an error when the question never appears", async () => {
+    const apiClient: any = {
+      createQuestion: jest.fn().mockResolvedValue({}),
+      exportQA: jest.fn().mockResolvedValue("[]"),
+    };
+
+    const result = await executeCommunicationTool(
+      "create-question",
+      { roomId: "r1", question: "Is this on?", participant },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("absent from the room's Q&A export");
+  });
+});
+
+describe("live session controls", () => {
+  it("does not claim a hand was raised when the API confirms nothing", async () => {
+    const apiClient: any = {
+      raiseParticipantHand: jest.fn().mockResolvedValue({}),
+    };
+
+    const result = await executeLiveSessionTool(
+      "raise-participant-hand",
+      { room_id: "r1", participant_id: "p1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toContain("not verified");
+    expect(textOf(result)).not.toContain("Successfully");
+  });
+
+  it("still surfaces API errors", async () => {
+    const apiClient: any = {
+      raiseParticipantHand: jest
+        .fn()
+        .mockRejectedValue(new Error("participant not found")),
+    };
+
+    const result = await executeLiveSessionTool(
+      "raise-participant-hand",
+      { room_id: "r1", participant_id: "p1" },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("participant not found");
+  });
+});

--- a/tests/unit/verified-writes.test.ts
+++ b/tests/unit/verified-writes.test.ts
@@ -286,9 +286,11 @@ describe("send-chat-message", () => {
     expect(textOf(result)).toContain("confirmed by read-back");
   });
 
-  it("does not verify against the export when the room does not persist chat", async () => {
-    // Without persistence an empty export proves nothing, so claiming failure
-    // would be as wrong as claiming delivery.
+  it("reports failure when the room offers no read-back, rather than 'unverified'", async () => {
+    // Without persistence there is no export to check. That used to mean the
+    // tool said "accepted, effect not verified" — a reassurance that cannot be
+    // true, since the platform delivers no chat at all (the signalling server
+    // has no chat endpoint; proven live 2026-08-14). Report the known failure.
     const apiClient: any = {
       getRoom: jest.fn().mockResolvedValue({ chat_persistence_enabled: false }),
       sendChatMessage: jest.fn().mockResolvedValue({}),
@@ -301,9 +303,45 @@ describe("send-chat-message", () => {
       apiClient,
     );
 
-    expect(result.isError).toBeUndefined();
-    expect(textOf(result)).toContain("not verified");
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("NOT delivered");
     expect(apiClient.exportChatMessages).not.toHaveBeenCalled();
+  });
+
+  it("still issues the request when it cannot verify", async () => {
+    // So the message lands the day the backend fix ships, rather than being
+    // dropped by us on the way out.
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ chat_persistence_enabled: false }),
+      sendChatMessage: jest.fn().mockResolvedValue({}),
+    };
+
+    await executeCommunicationTool(
+      "send-chat-message",
+      { roomId: "r1", message: "hello" },
+      apiClient,
+    );
+
+    expect(apiClient.sendChatMessage).toHaveBeenCalledWith("r1", {
+      message: "hello",
+      participant: undefined,
+    });
+  });
+
+  it("reports a transport error distinctly from an undeliverable message", async () => {
+    const apiClient: any = {
+      getRoom: jest.fn().mockResolvedValue({ chat_persistence_enabled: false }),
+      sendChatMessage: jest.fn().mockRejectedValue(new Error("boom")),
+    };
+
+    const result = await executeCommunicationTool(
+      "send-chat-message",
+      { roomId: "r1", message: "hello" },
+      apiClient,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain("boom");
   });
 });
 


### PR DESCRIPTION
Nine commits from the 2026-08-13/14 read-back sweep. Seven defects found; four were ours and are fixed here, three are the API's and are contained so they fail loudly instead of lying.

**Tag this v1.2.0, not v1.1.1** — it adds `list-polls` (144 → 145 tools). `package.json` is already bumped.

## The systemic fix

`src/tools/verified-write.ts` gives write handlers one path that reports only what was actually established: the response body's evidence where there is any, a read-back where one is cheap, and otherwise a plain statement that the request was accepted and nothing more.

Root cause was in the client, not the handlers — `sendChatMessage`, `createQuestion`, `answerQuestion` and friends were `Promise<void>` doing `await this.request<void>(...)`, discarding the body. So "create-question returns no ID" was never an established API limitation; we had simply never looked. Read-back is now wired into `import-polls`, `import-quizzes`, `create-question`, `answer-question` (which also recovers the question ID the create endpoint never returns) and `send-chat-message`.

## Ours, fixed

- **`update-role` dropped `displayName`** and **`update-webhook` dropped `authorizationHeader`** — both passed camelCase to a snake_case API via a rest spread; unknown fields ignored, still 200, reported as updated. `update-role` *partially* applied, which only read-back could catch.
- **`update-recording`** was a stub returning a bare message with no `isError` while advertising "rename recording".
- **`publish-poll-results`** posts to a route the backend does not define at all — no `publish` action exists anywhere. The "Session ID is required" text that made this look like an API constraint was our own guard, so the 404 never surfaced.
- **`copy-library-content`** had no copy endpoint either, and faked it with `createLibraryFile(name, size, mime_type)` — an empty placeholder stuck at `uploading`, reported as "Successfully copied file", for *every* file type. Webapps are now genuinely duplicated from their URL; stored files are refused; folders no longer call themselves copies.
- **`period`** on the analytics tools was never an API parameter (`StatisticsController` reads `date_start`/`date_end` only), so "last week" silently returned all-time figures. Now translated client-side into a real range.

Three of those five were found by reading the API source before reporting them as API bugs. They had been written up as the backend's.

## Theirs, contained

`import-polls`, `send-chat-message` and `connect-phone` remain broken for customers. What changes is that they now fail loudly. Written up with file:line in the project's `11-Backend-API-Issues.md`; the chat one is confirmed by the backend team with a fix scheduled.

## Also

- `create-room` exposes `tags` (POST accepts them, PATCH does not, so creation is the only chance)
- `delete-rooms-by-tag` stops claiming deletion — it is 202/async/uncounted
- new **`list-polls`** closes a real gap
- `scripts/smoke-test.mjs` (`npm run smoke`) is the release gate

## Verification

604 tests (was 525 at v1.1.0), lint and format clean. Smoke against dev after rebuild: **24 passed, 0 failed, 1 known issue** (`import-polls`, correctly reported as an API-side no-op), dev left clean.